### PR TITLE
Preprocessing to remove alignment data and word attributes

### DIFF
--- a/Dockerfile-developBranch
+++ b/Dockerfile-developBranch
@@ -6,6 +6,7 @@ FROM python:alpine
 ADD . /code
 WORKDIR /code
 
+RUN pip3 install --upgrade pip
 RUN pip3 install --requirement requirements.txt
 
 CMD [ "rq", "worker", "--config", "rq_settings", "--name", "D43_Dev_JobHandler" ]

--- a/Dockerfile-masterBranch
+++ b/Dockerfile-masterBranch
@@ -6,6 +6,7 @@ FROM python:alpine
 ADD . /code
 WORKDIR /code
 
+RUN pip3 install --upgrade pip
 RUN pip3 install --requirement requirements.txt
 
 CMD [ "rq", "worker", "--config", "rq_settings", "--name", "D43_JobHandler" ]

--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,14 @@ XXXclean_doc:
 	cd docs && rm -f source/enqueue*.rst
 
 dependencies:
+	pip3 install --upgrade pip
 	pip3 install --requirement requirements.txt
 
 testDependencies:
+	pip3 install --upgrade pip
 	pip3 install --requirement test_requirements.txt
 dependenciesTest:
+	pip3 install --upgrade pip
 	pip3 install --requirement test_requirements.txt
 
 # NOTE: The following environment variables are expected to be set for testing:

--- a/aws_tools/dynamodb_handler.py
+++ b/aws_tools/dynamodb_handler.py
@@ -3,7 +3,7 @@ from boto3 import Session
 from boto3.dynamodb.conditions import Attr
 
 
-class DynamoDBHandler(object):
+class DynamoDBHandler:
 
     def __init__(self, table_name, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):
         self.table_name = table_name

--- a/aws_tools/lambda_handler.py
+++ b/aws_tools/lambda_handler.py
@@ -18,7 +18,7 @@ class LambdaHandler:
 
     def invoke(self, function_name, payload, asyncFlag=False):
         invocation_type = 'RequestResponse' if not asyncFlag else 'Event'
-        print(f"INVOKE LAMBDA FUNCTION: {function_name} {invocation_type}...")
+        print(f"INVOKE LAMBDA FUNCTION: {function_name} {invocation_type} ...")
         #print("PAYLOAD1", repr(payload))
         #print("PAYLOAD2", repr(json.dumps(payload)))
         payloadString = json.dumps(payload)

--- a/aws_tools/lambda_handler.py
+++ b/aws_tools/lambda_handler.py
@@ -2,7 +2,7 @@ import json
 import boto3
 
 
-class LambdaHandler(object):
+class LambdaHandler:
     def __init__(self, aws_access_key_id=None, aws_secret_access_key=None, aws_region_name='us-west-2'):
         self.aws_access_key_id = aws_access_key_id
         self.aws_secret_access_key = aws_secret_access_key

--- a/aws_tools/s3_handler.py
+++ b/aws_tools/s3_handler.py
@@ -7,7 +7,7 @@ from boto3.session import Session
 from general_tools.file_utils import get_mime_type
 
 
-class S3Handler(object):
+class S3Handler:
     def __init__(self, bucket_name=None, aws_access_key_id=None, aws_secret_access_key=None,
                  aws_region_name='us-west-2'):
         self.bucket_name = bucket_name

--- a/callback.py
+++ b/callback.py
@@ -111,13 +111,16 @@ def process_callback(pc_prefix, queued_json_payload, redis_connection):
         this_job_dict[fieldname] = matched_job_dict[fieldname]
 
     if 'preprocessor_warnings' in matched_job_dict:
-        # GlobalSettings.logger.debug(f"Got remembered preprocessor_warnings: {matched_job_dict['preprocessor_warnings']}")
+        # GlobalSettings.logger.debug(f"Got {len(matched_job_dict['preprocessor_warnings'])}"
+        #                            f" remembered preprocessor_warnings: {matched_job_dict['preprocessor_warnings']}")
         # Prepend preprocessor results to linter warnings
-        queued_json_payload['linter_warnings'] = matched_job_dict['preprocessor_warnings'] + queued_json_payload['linter_warnings']
-        GlobalSettings.logger.debug(f"Now have linter_warnings: {queued_json_payload['linter_warnings']}")
+        total_warnings = len(matched_job_dict['preprocessor_warnings']) + len(queued_json_payload['linter_warnings'])
+        queued_json_payload['linter_warnings'] = matched_job_dict['preprocessor_warnings'] \
+                                               + queued_json_payload['linter_warnings']
+        GlobalSettings.logger.debug(f"Now have {len(queued_json_payload['linter_warnings'])}"
+                                    f" linter_warnings: {queued_json_payload['linter_warnings']}")
+        assert len(queued_json_payload['linter_warnings']) == total_warnings
         del matched_job_dict['preprocessor_warnings'] # No longer required
-    assert 'preprocessor_warnings' not in matched_job_dict
-    assert 'preprocessor_warnings' not in queued_json_payload
 
     if 'identifier' in queued_json_payload:
         identifier = queued_json_payload['identifier']
@@ -147,9 +150,6 @@ def process_callback(pc_prefix, queued_json_payload, redis_connection):
                                   queued_json_payload['converter_errors'])
     ccc_build_log = ccc.process_callback()
     final_build_log = ccc_build_log
-    assert 'preprocessor_warnings' not in matched_job_dict
-    assert 'preprocessor_warnings' not in queued_json_payload
-    assert 'preprocessor_warnings' not in final_build_log
     GlobalSettings.logger.info(f"Door43-Job-Handler process_callback() is finishing with {final_build_log}")
     #return build_log_json
 #end of process_callback function

--- a/callback.py
+++ b/callback.py
@@ -114,12 +114,12 @@ def process_callback(pc_prefix, queued_json_payload, redis_connection):
         # GlobalSettings.logger.debug(f"Got {len(matched_job_dict['preprocessor_warnings'])}"
         #                            f" remembered preprocessor_warnings: {matched_job_dict['preprocessor_warnings']}")
         # Prepend preprocessor results to linter warnings
-        total_warnings = len(matched_job_dict['preprocessor_warnings']) + len(queued_json_payload['linter_warnings'])
+        # total_warnings = len(matched_job_dict['preprocessor_warnings']) + len(queued_json_payload['linter_warnings'])
         queued_json_payload['linter_warnings'] = matched_job_dict['preprocessor_warnings'] \
                                                + queued_json_payload['linter_warnings']
-        GlobalSettings.logger.debug(f"Now have {len(queued_json_payload['linter_warnings'])}"
-                                    f" linter_warnings: {queued_json_payload['linter_warnings']}")
-        assert len(queued_json_payload['linter_warnings']) == total_warnings
+        # GlobalSettings.logger.debug(f"Now have {len(queued_json_payload['linter_warnings'])}"
+        #                             f" linter_warnings: {queued_json_payload['linter_warnings']}")
+        # assert len(queued_json_payload['linter_warnings']) == total_warnings
         del matched_job_dict['preprocessor_warnings'] # No longer required
 
     if 'identifier' in queued_json_payload:

--- a/client_converter_callback.py
+++ b/client_converter_callback.py
@@ -126,14 +126,14 @@ class ClientConverterCallback:
         if multiple_project:
             upload_key += '/' + part_id
 
-        GlobalSettings.logger.debug(f"Callback for commit {s3_commit_key}...")
+        GlobalSettings.logger.debug(f"Callback for commit {s3_commit_key} ...")
 
         # Download the ZIP file of the converted files
         converted_zip_url = self.job.output
         converted_zip_file = os.path.join(self.temp_dir, converted_zip_url.rpartition('/')[2])
         remove(converted_zip_file)  # make sure old file not present
         download_success = True
-        GlobalSettings.logger.debug(f"Downloading converted zip file from {converted_zip_url}...")
+        GlobalSettings.logger.debug(f"Downloading converted zip file from {converted_zip_url} ...")
         try:
             download_file(converted_zip_url, converted_zip_file)
         except:
@@ -183,7 +183,7 @@ class ClientConverterCallback:
     def unzip_converted_files(self, converted_zip_file):
         unzip_dir = tempfile.mkdtemp(prefix='unzip_', dir=self.temp_dir)
         try:
-            GlobalSettings.logger.debug(f"Unzipping {converted_zip_file}...")
+            GlobalSettings.logger.debug(f"Unzipping {converted_zip_file} ...")
             unzip(converted_zip_file, unzip_dir)
         finally:
             GlobalSettings.logger.debug("finished.")

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -81,7 +81,7 @@ class ClientLinterCallback:
             build_log['warnings'].append(msg)
             GlobalSettings.logger.error(msg)
         else:
-            GlobalSettings.logger.debug("Linter {0} {1} warnings:\n{1}".format(self.identifier, len(self.warnings),
+            GlobalSettings.logger.debug("Linter {0} {1} warnings:\n{2}".format(self.identifier, len(self.warnings),
                                                                     '\n'.join(self.warnings[:5])))
 
         has_warnings = len(build_log['warnings']) > 0
@@ -230,7 +230,7 @@ class ClientLinterCallback:
         key = f'{s3_results_key}/finished'
         try:
             convert_finished = GlobalSettings.cdn_s3_handler().key_exists(key)
-        except Exception as e:
+        except Exception:
             convert_finished = False
         return convert_finished
 

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -81,8 +81,8 @@ class ClientLinterCallback:
             build_log['warnings'].append(msg)
             GlobalSettings.logger.error(msg)
         else:
-            GlobalSettings.logger.debug("Linter {0} {1} warnings:\n{2}".format(self.identifier, len(self.warnings),
-                                                                    '\n'.join(self.warnings[:5])))
+            GlobalSettings.logger.debug("Linter {0} had success with {1} warnings: {2}...".format(self.identifier, len(self.warnings),
+                                                                    ', '.join(self.warnings[:5])))
 
         has_warnings = len(build_log['warnings']) > 0
         if has_warnings:

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -133,7 +133,8 @@ class ClientLinterCallback:
             build_log = ClientLinterCallback.merge_build_status_for_part(build_log, s3_results_key, output_dir)
         else:
             GlobalSettings.logger.debug('Multiple parts: Checking if all parts completed.')
-            job_id, part_count, part_id, book = id_parts[:4]
+            # job_id, part_count, part_id, book = id_parts[:4]
+            part_count = id_parts[1]
             for i in range(0, int(part_count)):
                 part_key = f'{s3_results_key}/{i}'
                 build_log = ClientLinterCallback.merge_build_status_for_part(build_log, part_key, output_dir)
@@ -164,8 +165,11 @@ class ClientLinterCallback:
         return build_log
 
     @staticmethod
-    def update_jobs_table(s3_results_key, build_log, output_dir):
-        GlobalSettings.logger.debug(f"update_jobs_table({s3_results_key}, {build_log}, {output_dir})")
+    def upload_logs(s3_results_key, build_log, output_dir):
+        """
+        Was update_jobs_table
+        """
+        GlobalSettings.logger.debug(f"upload_logs({s3_results_key}, {build_log}, {output_dir})")
 
         job_id = build_log['job_id']
         GlobalSettings.logger.debug('merging build_logs for job : ' + job_id)
@@ -212,7 +216,7 @@ class ClientLinterCallback:
                 if part_build_log_combined:
                     build_log = ClientLinterCallback.merge_results_logs(build_log, part_build_log_combined,
                                                                         linter_file=False)
-                    ClientLinterCallback.update_jobs_table(s3_results_key, part_build_log_combined, output_dir)
+                    ClientLinterCallback.upload_logs(s3_results_key, part_build_log_combined, output_dir)
                     return build_log
                 else:
                     GlobalSettings.logger.debug(f"Lint_log.json not found for {s3_results_key}")

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -4,8 +4,7 @@ import time
 from datetime import datetime
 
 from global_settings.global_settings import GlobalSettings
-from general_tools import file_utils
-from general_tools.file_utils import unzip, write_file, remove_tree, remove
+from general_tools.file_utils import write_file, remove_tree
 
 
 class ClientLinterCallback:
@@ -51,7 +50,7 @@ class ClientLinterCallback:
             raise Exception(error)
 
         if not self.s3_results_key:
-            error = 'No s3_results_key found for identifier = {0}'.format(self.identifier)
+            error = f"No s3_results_key found for identifier = {self.identifier}"
             GlobalSettings.logger.error(error)
             raise Exception(error)
 
@@ -81,15 +80,15 @@ class ClientLinterCallback:
             build_log['warnings'].append(msg)
             GlobalSettings.logger.error(msg)
         else:
-            GlobalSettings.logger.debug("Linter {0} had success with {1} warnings: {2}...".format(self.identifier, len(self.warnings),
-                                                                    ', '.join(self.warnings[:5])))
+            GlobalSettings.logger.debug(f"Linter {self.identifier} had success with"
+                                        f" {len(self.warnings)} warnings: {', '.join(self.warnings[:5])} ...")
 
         has_warnings = len(build_log['warnings']) > 0
         if has_warnings:
-            msg = "Linter {0} has Warnings!".format(self.identifier)
+            msg = f"Linter {self.identifier} has Warnings!"
             build_log['log'].append(msg)
         else:
-            msg = "Linter {0} completed with no warnings".format(self.identifier)
+            msg = f"Linter {self.identifier} completed with no warnings"
             build_log['log'].append(msg)
 
         ClientLinterCallback.upload_build_log(build_log, 'lint_log.json', self.temp_dir, self.s3_results_key)
@@ -107,7 +106,7 @@ class ClientLinterCallback:
     def upload_build_log(build_log, file_name, output_dir, s3_results_key, cache_time=0):
         build_log_file = os.path.join(output_dir, file_name)
         write_file(build_log_file, build_log)
-        upload_key = '{0}/{1}'.format(s3_results_key, file_name)
+        upload_key = f'{s3_results_key}/{file_name}'
         GlobalSettings.logger.debug('Saving build log to ' + upload_key)
         GlobalSettings.cdn_s3_handler().upload_file(build_log_file, upload_key, cache_time=cache_time)
 
@@ -161,7 +160,7 @@ class ClientLinterCallback:
             GlobalSettings.logger.debug('Not all parts completed')
             build_log = None
 
-        file_utils.remove_tree(output_dir)
+        remove_tree(output_dir)
         return build_log
 
     @staticmethod
@@ -240,13 +239,13 @@ class ClientLinterCallback:
 
     @staticmethod
     def get_results(s3_results_key, file_name):
-        key = "{0}/{1}".format(s3_results_key, file_name)
+        key = f'{s3_results_key}/{file_name}'
         file_results = GlobalSettings.cdn_s3_handler().get_json(key)
         return file_results
 
     @staticmethod
     def merge_build_status_for_file(build_log, s3_results_key, file_name, linter_file=False):
-        key = "{0}/{1}".format(s3_results_key, file_name)
+        key = f'{s3_results_key}/{file_name}'
         file_results = GlobalSettings.cdn_s3_handler().get_json(key)
         if file_results:
             build_log = ClientLinterCallback.merge_results_logs(build_log, file_results, linter_file)
@@ -280,11 +279,11 @@ class ClientLinterCallback:
         commit_id = build_log['commit_id']
         user_name = build_log['repo_owner']
         repo_name = build_log['repo_name']
-        project_json_key = 'u/{0}/{1}/project.json'.format(user_name, repo_name)
+        project_json_key = f'u/{user_name}/{repo_name}/project.json'
         project_json = GlobalSettings.cdn_s3_handler().get_json(project_json_key)
         project_json['user'] = user_name
         project_json['repo'] = repo_name
-        project_json['repo_url'] = 'https://{0}/{1}/{2}'.format(GlobalSettings.gogs_url, user_name, repo_name)
+        project_json['repo_url'] = f'https://{GlobalSettings.gogs_url}/{user_name}/{repo_name}'
         commit = {
             'id': commit_id,
             'created_at': build_log['created_at'],

--- a/door43_tools/td_language.py
+++ b/door43_tools/td_language.py
@@ -3,7 +3,7 @@ import json
 from general_tools import url_utils
 
 
-class TdLanguage(object):
+class TdLanguage:
 
     language_list = {}
 

--- a/general_tools/file_utils.py
+++ b/general_tools/file_utils.py
@@ -1,4 +1,3 @@
-import codecs
 import json
 import os
 import sys
@@ -73,7 +72,7 @@ def make_dir(dir_name, linux_mode=0o755, error_if_not_writable=False):
         os.makedirs(dir_name, linux_mode)
     elif error_if_not_writable:
         if not os.access(dir_name, os.R_OK | os.W_OK | os.X_OK):
-            raise IOError('Directory {0} is not writable.'.format(dir_name))
+            raise IOError(f"Directory {dir_name} is not writable.")
 
 
 def load_json_object(file_name, default=None):
@@ -101,7 +100,7 @@ def load_yaml_object(file_name, default=None):
 
 
 def read_file(file_name, encoding='utf-8-sig'):
-    with codecs.open(file_name, 'r', encoding=encoding) as f:
+    with open(file_name, 'r', encoding=encoding) as f:
         content = f.read()
     # convert Windows line endings to Linux line endings
     content = content.replace('\r\n', '\n')
@@ -118,7 +117,7 @@ def write_file(file_name, file_contents, indent=None):
     :param str|unicode|object file_contents: The string to write or the object to serialize
     :param int indent: Specify a value if you want the output formatted to be more easily readable
     """
-    # make sure the directory exists
+    # Make sure the directory exists
     make_dir(os.path.dirname(file_name))
 
     if isinstance(file_contents, str):
@@ -129,7 +128,7 @@ def write_file(file_name, file_contents, indent=None):
         else:
             text_to_write = json.dumps(file_contents, sort_keys=True, indent=indent, default=json_serial)
 
-    with codecs.open(file_name, 'w', encoding='utf-8') as out_file:
+    with open(file_name, 'w', encoding='utf-8') as out_file:
         out_file.write(text_to_write)
 
 
@@ -138,7 +137,7 @@ def get_mime_type(path):
 
     mime_type = mime.guess_type(path)[0]
     if not mime_type:
-        mime_type = "text/{0}".format(os.path.splitext(path)[1])
+        mime_type = f'text/{os.path.splitext(path)[1]}'
     return mime_type
 
 

--- a/global_settings/global_settings.py
+++ b/global_settings/global_settings.py
@@ -47,8 +47,7 @@ def setup_logger(logger, level):
     for h in logger.handlers:
         logger.removeHandler(h)
     sh = logging.StreamHandler(sys.stdout)
-    head = '%(asctime)s - %(levelname)s: %(message)s'
-    sh.setFormatter(logging.Formatter(head))
+    sh.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s: %(message)s'))
     logger.addHandler(sh)
     logger.setLevel(level)
     # Change these loggers to only report errors:

--- a/global_settings/global_settings.py
+++ b/global_settings/global_settings.py
@@ -3,7 +3,7 @@ import os
 import logging
 import re
 
-from sqlalchemy import *
+from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool

--- a/gogs_tools/gogs_handler.py
+++ b/gogs_tools/gogs_handler.py
@@ -2,7 +2,7 @@ from gogs_client import GogsApi
 from gogs_client import Token
 
 
-class GogsHandler(object):
+class GogsHandler:
     def __init__(self, gogs_url):
         self.gogs_url = gogs_url
         self.gogs_api = GogsApi(gogs_url)

--- a/models/tx_model.py
+++ b/models/tx_model.py
@@ -5,7 +5,7 @@ from sqlalchemy import inspect
 from global_settings.global_settings import GlobalSettings
 
 
-class TxModel(object):
+class TxModel:
 
     def __init__(self, **kwargs):
         pass

--- a/preprocessors/preprocessors.py
+++ b/preprocessors/preprocessors.py
@@ -5,7 +5,7 @@ from shutil import copy
 
 from global_settings.global_settings import GlobalSettings
 from door43_tools.bible_books import BOOK_NUMBERS, BOOK_NAMES, BOOK_CHAPTER_VERSES
-from general_tools.file_utils import write_file, read_file
+from general_tools.file_utils import write_file, read_file, make_dir
 from resource_container.ResourceContainer import RC
 
 
@@ -34,7 +34,7 @@ def do_preprocess(rc, repo_dir, output_dir):
     return preprocessor.run(), preprocessor
 
 
-class Preprocessor(object):
+class Preprocessor:
     # NOTE: Both of these lists are used for case-sensitive comparisons
     ignoreDirectories = ['.git', '00']
     ignoreFiles = ['.DS_Store', 'reference.txt', 'title.txt', 'LICENSE.md', 'README.md', 'README.rst']
@@ -60,7 +60,7 @@ class Preprocessor(object):
         Case #2: It's a directory of files, so we copy them over to the output directory
         Case #3: The project path is multiple chapters, so we piece them together
         """
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"Default preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         for idx, project in enumerate(self.rc.projects):
             project_path = os.path.join(self.source_dir, project.path)
 
@@ -179,7 +179,7 @@ class ObsPreprocessor(Preprocessor):
         return False
 
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"Obs preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         for project in self.rc.projects:
             GlobalSettings.logger.debug(f"OBS preprocessor: Copying markdown files for '{project.identifier}'")
             project_path = os.path.join(self.source_dir, project.path)
@@ -223,8 +223,117 @@ class BiblePreprocessor(Preprocessor):
         self.book_filenames.sort()
         return self.book_filenames
 
+    @staticmethod
+    def write_clean_file(file_name, file_contents):
+        """
+        Cleans the USFM text as it writes it.
+        """
+        # GlobalSettings.logger.debug(f"write_clean_file( {file_name}, {file_contents[:500]+('...' if len(file_contents)>500 else '')} )")
+
+        # Replacing this code:
+        # write_file(file_name, file_contents)
+        # return
+
+        # Make sure the directory exists
+        make_dir(os.path.dirname(file_name))
+
+        # Clean the USFM
+        preadjusted_file_contents = file_contents
+        # First do global fixes to bad tC USFM
+        preadjusted_file_contents = re.sub(r'\\(q[123]?)([^ ])', r'\\\1 \2', preadjusted_file_contents) # Fix bad USFM \q without following space
+        preadjusted_file_contents = re.sub(r'\\p([^ ])', r'\\p \1', preadjusted_file_contents) # Fix bad USFM \p without following space
+        # Then do other global changes
+        preadjusted_file_contents = preadjusted_file_contents.replace('\\zaln-e\\*', '') # Remove self-closing milestones
+
+        # Then do line-by-line changes
+        needs_new_line = needs_global_check = False
+        adjusted_file_contents = ''
+        B = file_name[-8:-5] # Extract book abbreviation from somepath/nn-BBB.usfm
+        C = V = ''
+        for line in preadjusted_file_contents.split('\n'):
+            if not line: continue # Ignore blank lines
+            # GlobalSettings.logger.debug(f"Processing line: {line!r}")
+
+            # # Get C,V for debug messages
+            # if line.startswith('\\c '):
+            #     C = line[3:]
+            # elif line.startswith('\\v '):
+            #     V = line[3:]
+
+            adjusted_line = line
+            ixW = adjusted_line.find('\\w ')
+            while ixW != -1:
+                ixEnd = adjusted_line.find('\\w*')
+                assert ixEnd != -1 # Fail if closing marker is missing from the line
+                field = adjusted_line[ixW+3:ixEnd]
+                # GlobalSettings.logger.debug(f"Cleaning \\w field: {field!r} from '{line}'")
+                bits = field.split('|')
+                adjusted_field = bits[0]
+                # GlobalSettings.logger.debug(f"Adjusted field to: {adjusted_field!r}")
+                adjusted_line = adjusted_line[:ixW] + adjusted_field + adjusted_line[ixEnd+3:]
+                # GlobalSettings.logger.debug(f"Adjusted line to: '{adjusted_line}'")
+                ixW = adjusted_line.find('\\w ') # Might be another one
+            assert '\\w ' not in adjusted_line
+            assert '\\w*' not in adjusted_line
+            if '\\z' in adjusted_line: # Delete these user-defined fields
+                # GlobalSettings.logger.debug(f"Processing user-defined line: {line}")
+                ix = adjusted_line.find('\\zaln-s')
+                if ix != -1:
+                    adjusted_line = adjusted_line[:ix] # Remove zaln-s field right up to end of line
+            assert '\\z' not in adjusted_line
+            if not adjusted_line: # was probably just a \zaln-s milestone with nothing else
+                continue
+            if adjusted_line != line: # it's non-blank and it changed
+                # if 'EPH' in file_name:
+                    #  GlobalSettings.logger.debug(f"Adjusted {B} {C}:{V} \\w line from {line!r} to {adjusted_line!r}")
+                adjusted_file_contents += ' ' + adjusted_line
+                needs_new_line = True
+                continue
+            assert adjusted_line == line # No \w or \z fields encountered
+
+            if needs_new_line:
+                adjusted_file_contents += '\n'
+                needs_new_line = False
+                needs_global_check = True
+
+            # Copy across unchanged lines
+            # GlobalSettings.logger.debug(f"Using line: {line}")
+            adjusted_file_contents += line + '\n'
+
+        if needs_global_check: # Do some file-wide clean-up
+            GlobalSettings.logger.debug(f"Doing global fixes for {B}")
+            adjusted_file_contents = adjusted_file_contents.replace('\n ',' ') # Move lines starting with space up to the previous line
+            adjusted_file_contents = re.sub(r'\n([,.])', r'\1', adjusted_file_contents) # Bring leading punctuation up onto the previous line
+            adjusted_file_contents = re.sub(r'([^\n])\\s5', r'\1\n\\s5', adjusted_file_contents) # Make sure \s5 goes onto separate line
+            adjusted_file_contents = adjusted_file_contents.replace('\n\n','\n') # Delete blank lines
+
+        # Write the modified USFM
+        # if 'EPH' in file_name:
+            # GlobalSettings.logger.debug(f"Writing {file_name}: {adjusted_file_contents[:1000]}...")
+        if '\\w' in adjusted_file_contents:
+            GlobalSettings.logger.debug(f"Writing {file_name}: {adjusted_file_contents}")
+        assert '\\w' not in adjusted_file_contents
+        with open(file_name, 'wt', encoding='utf-8') as out_file:
+            out_file.write(adjusted_file_contents)
+
+
+    @staticmethod
+    def clean_copy(source_pathname, destination_pathname):
+        """
+        Cleans the USFM file as it copies it.
+        """
+        # GlobalSettings.logger.debug(f"clean_copy( {source_pathname}, {destination_pathname} )")
+
+        # Replacing this code:
+        # copy(source_pathname, destination_pathname)
+        # return
+
+        with open(source_pathname, 'rt') as in_file:
+            source_contents = in_file.read()
+        BiblePreprocessor.write_clean_file(destination_pathname, source_contents)
+
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"Bible preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         for idx, project in enumerate(self.rc.projects):
             project_path = os.path.join(self.source_dir, project.path)
             file_format = '{0}-{1}.usfm'
@@ -236,7 +345,8 @@ class BiblePreprocessor(Preprocessor):
                     filename = file_format.format(BOOK_NUMBERS[project.identifier.lower()], project.identifier.upper())
                 else:
                     filename = file_format.format(str(idx+1).zfill(2), project.identifier.upper())
-                copy(project_path, os.path.join(self.output_dir, filename))
+                # copy(project_path, os.path.join(self.output_dir, filename))
+                BiblePreprocessor.clean_copy(project_path, os.path.join(self.output_dir, filename))
                 self.book_filenames.append(filename)
             else:
                 # Case #2: Project path is a dir with one or more USFM files, is one or more books of the Bible
@@ -248,10 +358,11 @@ class BiblePreprocessor(Preprocessor):
                         if book_code in BOOK_NUMBERS:
                             filename = file_format.format(BOOK_NUMBERS[book_code], book_code.upper())
                         else:
-                            filename = '{0}.usfm'.format(os.path.splitext(os.path.basename(usfm_path))[0])
+                            filename = f'{os.path.splitext(os.path.basename(usfm_path))[0]}.usfm'
                         output_file_path = os.path.join(self.output_dir, filename)
                         if os.path.isfile(usfm_path) and not os.path.exists(output_file_path):
-                            copy(usfm_path, output_file_path)
+                            # copy(usfm_path, output_file_path)
+                            BiblePreprocessor.clean_copy(usfm_path, output_file_path)
                         self.book_filenames.append(filename)
                 else:
                     # Case #3: Project path is a dir with one or more chapter dirs with chunk & title files
@@ -304,7 +415,8 @@ class BiblePreprocessor(Preprocessor):
                                                           project.identifier.upper())
                         else:
                             filename = file_format.format(str(idx + 1).zfill(2), project.identifier.upper())
-                        write_file(os.path.join(self.output_dir, filename), usfm)
+                        # write_file(os.path.join(self.output_dir, filename), usfm)
+                        BiblePreprocessor.write_clean_file(os.path.join(self.output_dir, filename), usfm)
                         self.book_filenames.append(filename)
         GlobalSettings.logger.debug(f"Preprocessor returning with {self.output_dir} = {os.listdir(self.output_dir)}")
         return True
@@ -404,7 +516,7 @@ class TaPreprocessor(Preprocessor):
         return markdown
 
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"tA preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         for idx, project in enumerate(self.rc.projects):
             GlobalSettings.logger.debug(f"tA preprocessor: Copying files for '{project.identifier}'")
             self.section_container_id = 1
@@ -462,7 +574,7 @@ class TaPreprocessor(Preprocessor):
 class TqPreprocessor(Preprocessor):
 
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"tQ preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         index_json = {
             'titles': {},
             'chapters': {},
@@ -520,7 +632,7 @@ class TwPreprocessor(Preprocessor):
     }
 
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"tW preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         index_json = {
             'titles': {},
             'chapters': {},
@@ -621,7 +733,7 @@ class TnPreprocessor(Preprocessor):
         return self.book_filenames
 
     def run(self):
-        GlobalSettings.logger.debug(f"Preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
+        GlobalSettings.logger.debug(f"tN preprocessor starting with {self.source_dir} = {os.listdir(self.source_dir)}")
         index_json = {
             'titles': {},
             'chapters': {},

--- a/preprocessors/preprocessors.py
+++ b/preprocessors/preprocessors.py
@@ -290,7 +290,7 @@ class BiblePreprocessor(Preprocessor):
                                 translated_title = read_file(os.path.join(project_path, chapter, 'title.txt'))
                                 book_name = re.sub(r' \d+$', '', translated_title).strip()
                                 if book_name.lower() != title.lower():
-                                    usfm += f'\cl {translated_title}\n'
+                                    usfm += f'\\cl {translated_title}\n'
                             for chunk in chunks:
                                 if chunk in self.ignoreFiles:
                                     continue
@@ -469,7 +469,7 @@ class TqPreprocessor(Preprocessor):
             'book_codes': {}
         }
         headers_re = re.compile('^(#+) +(.+?) *#*$', flags=re.MULTILINE)
-        for idx, project in enumerate(self.rc.projects):
+        for project in self.rc.projects:
             GlobalSettings.logger.debug(f"tQ preprocessor: Combining chapters for '{project.identifier}'")
             if project.identifier in BOOK_NAMES:
                 markdown = ''
@@ -490,6 +490,7 @@ class TqPreprocessor(Preprocessor):
                     for chunk_idx, chunk_file in enumerate(chunk_files):
                         start_verse = os.path.splitext(os.path.basename(chunk_file))[0].lstrip('0')
                         if chunk_idx < len(chunk_files)-1:
+                            # TODO: Can throw a ValueError if chunk is not an integer, e.g., '5&8'
                             end_verse = str(int(os.path.splitext(os.path.basename(chunk_files[chunk_idx+1]))[0])-1)
                         else:
                             end_verse = BOOK_CHAPTER_VERSES[book][chapter.lstrip('0')]
@@ -527,7 +528,7 @@ class TwPreprocessor(Preprocessor):
         }
         title_re = re.compile('^# +(.*?) *#*$', flags=re.MULTILINE)
         headers_re = re.compile('^(#+) +(.+?) *#*$', flags=re.MULTILINE)
-        for idx, project in enumerate(self.rc.projects):
+        for project in self.rc.projects:
             GlobalSettings.logger.debug(f"tW preprocessor: Copying files for '{project.identifier}'")
             term_text = {}
             section_dirs = sorted(glob(os.path.join(self.source_dir, project.path, '*')))
@@ -627,7 +628,7 @@ class TnPreprocessor(Preprocessor):
             'book_codes': {}
         }
         headers_re = re.compile('^(#+) +(.+?) *#*$', flags=re.MULTILINE)
-        for idx, project in enumerate(self.rc.projects):
+        for project in self.rc.projects:
             GlobalSettings.logger.debug(f"tN preprocessor: Copying files for '{project.identifier}'")
             if project.identifier in BOOK_NAMES:
                 markdown = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # rq and statsd/Graphite is used by the job handler
 rq==0.12.0
-statsd==3.2.2
+statsd==3.3.0
 requests==2.19.1
 
 # yaml is used by file_utils used by ResourceContainer

--- a/resource_container/ResourceContainer.py
+++ b/resource_container/ResourceContainer.py
@@ -675,7 +675,7 @@ def get_manifest_from_repo_name(repo_name):
     parts = re.findall(r'[A-Za-z0-9]+', repo_name)
 
     language_set = False
-    for i, part in enumerate(parts):
+    for part in parts:
         if not language_set:
             if part == 'en':
                 # Speeds things up for English repos

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,6 @@
 # rq and statsd/Graphite is used by the job handler
 rq==0.12.0
-statsd==3.2.2
+statsd==3.3.0
 requests==2.19.1
 
 # yaml is used by file_utils used by ResourceContainer

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -24,5 +24,5 @@ gogs_client==1.0.6
 # FOR TESTING ONLY
 mock==2.0.0
 moto==1.3.3
-bs4==0.0.1
+beautifulsoup4==4.6.3
 markdown2==2.3.5

--- a/tests/client_tests/test_tn_preprocessor.py
+++ b/tests/client_tests/test_tn_preprocessor.py
@@ -36,11 +36,11 @@ class TestTnPreprocessor(unittest.TestCase):
         repo_name = 'dummy_repo'
 
         # when
-        results, preproc = do_preprocess(rc, repo_dir, self.out_dir)
+        results = do_preprocess(rc, repo_dir, self.out_dir)
 
         # then
-        self.assertTrue(preproc.is_multiple_jobs())
-        self.assertEqual(len(preproc.get_book_list()), 66)
+        # self.assertTrue(preproc.is_multiple_jobs())
+        # self.assertEqual(len(preproc.get_book_list()), 66)
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'index.json')))
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, '01-GEN.md')))
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, '67-REV.md')))
@@ -59,11 +59,11 @@ class TestTnPreprocessor(unittest.TestCase):
         repo_name = 'dummy_repo'
 
         # when
-        results, preproc = do_preprocess(rc, repo_dir, self.out_dir)
+        results = do_preprocess(rc, repo_dir, self.out_dir)
 
         # then
-        self.assertTrue(preproc.is_multiple_jobs())
-        self.assertEqual(len(preproc.get_book_list()), 2)
+        # self.assertTrue(preproc.is_multiple_jobs())
+        # self.assertEqual(len(preproc.get_book_list()), 2)
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'index.json')))
         self.assertFalse(os.path.isfile(os.path.join(self.out_dir, '01-GEN.md')))
         self.assertFalse(os.path.isfile(os.path.join(self.out_dir, '67-REV.md')))

--- a/tests/client_tests/test_tw_preprocessor.py
+++ b/tests/client_tests/test_tw_preprocessor.py
@@ -37,7 +37,7 @@ class TestTwPreprocessor(unittest.TestCase):
         self.out_dir = tempfile.mkdtemp(prefix='output_')
 
         # when
-        results, preproc = do_preprocess(rc, repo_dir, self.out_dir)
+        results = do_preprocess(rc, repo_dir, self.out_dir)
 
         # then
         self.assertTrue(os.path.isfile(os.path.join(self.out_dir, 'index.json')))

--- a/webhook.py
+++ b/webhook.py
@@ -219,9 +219,9 @@ def remember_job(rj_job_dict, rj_redis_connection):
     if outstanding_jobs_dict is None:
         GlobalSettings.logger.info("Created new outstanding_jobs_dict")
         outstanding_jobs_dict = {}
-    else:
-        GlobalSettings.logger.debug(f"Got outstanding_jobs_dict: "
-                                    f" ({len(outstanding_jobs_dict)}) {outstanding_jobs_dict.keys()}")
+    # else:
+    #    GlobalSettings.logger.debug(f"Got outstanding_jobs_dict: "
+    #                                f" ({len(outstanding_jobs_dict)}) {outstanding_jobs_dict.keys()}")
 
     if outstanding_jobs_dict:
         GlobalSettings.logger.info(f"Already had {len(outstanding_jobs_dict)}"

--- a/webhook.py
+++ b/webhook.py
@@ -392,7 +392,10 @@ def process_job(queued_json_payload, redis_connection):
     # Preprocess the files
     GlobalSettings.logger.info("Preprocessing files...")
     preprocess_dir = tempfile.mkdtemp(dir=base_temp_dir_name, prefix='preprocess_')
-    do_preprocess(rc, repo_dir, preprocess_dir)
+    preprocessor_result = do_preprocess(rc, repo_dir, preprocess_dir)
+    # preprocess_result is normally True, but can be a warning dict for the Bible preprocessor
+    preprocessor_warning_list = preprocessor_result if isinstance(preprocessor_result, list) else None
+    GlobalSettings.logger.debug(f"Preprocessor warning list is {preprocessor_warning_list}")
 
 
     # Zip up the massaged files
@@ -431,6 +434,8 @@ def process_job(queued_json_payload, redis_connection):
         'rel': 'self',
         'method': 'GET'
     }
+    if preprocessor_warning_list:
+        pj_job_dict['preprocessor_warnings'] = preprocessor_warning_list
     pj_job_dict['status'] = None
     pj_job_dict['success'] = False
 


### PR DESCRIPTION
By removing unneeded stuff, the existing linters and converters can be used in tX Job Handler. Preprocessor warnings are prepended to linter warnings. Some other small tidy-ups.