### PR TITLE
Various small improvements in subject detection and .txt Bible preprocessing

### DIFF
--- a/callback.py
+++ b/callback.py
@@ -164,13 +164,12 @@ def process_callback(pc_prefix, queued_json_payload, redis_connection):
     final_build_log = ccc_build_log
 
     # Now deploy the new pages (was previously a separate AWS Lambda call)
-    # if final_build_log['success']=='True' \
-    # or final_build_log['status'] in ('success', 'warnings'):
     GlobalSettings.logger.info(f"Deploying to the website (convert status={final_build_log['status']})…")
     deployer = ProjectDeployer()
-    build_log_key = f'{url_part2}/build_log.json'
-    GlobalSettings.logger.debug(f"Got {GlobalSettings.cdn_bucket_name} build_log_key={build_log_key}")
-    deployer.deploy_revision_to_door43(build_log_key)
+    # build_log_key = f'{url_part2}/build_log.json'
+    # GlobalSettings.logger.debug(f"Got {GlobalSettings.cdn_bucket_name} build_log_key={build_log_key}")
+    # deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
+    deployer.deploy_revision_to_door43(final_build_log) # No need to download the build log since we have it here
 
     # Finishing off
     GlobalSettings.logger.info(f"Door43-Job-Handler process_callback() for {job_descriptive_name} is finishing with {final_build_log}")

--- a/door43_tools/project_deployer.py
+++ b/door43_tools/project_deployer.py
@@ -42,12 +42,14 @@ class ProjectDeployer:
     #     self.close()
 
 
-    # TODO: Since this code is now inline, should be able to avoid downloading the build_log when we already have it
-    def deploy_revision_to_door43(self, build_log_key):
+    def download_buildlog_and_deploy_revision_to_door43(self, build_log_key):
         """
         Deploys a single revision of a project to door43.org
         :param string build_log_key:
         :return bool:
+
+        Was used by Lambda function
+            but now only called by test routines.
         """
         build_log = None
         try:
@@ -61,6 +63,15 @@ class ProjectDeployer:
             GlobalSettings.logger.debug(f"Exiting, Invalid build log at {build_log_key}: {build_log}")
             return False
 
+        return self.deploy_revision_to_door43(build_log)
+
+
+    def deploy_revision_to_door43(self, build_log):
+        """
+        Deploys a single revision of a project to door43.org
+        :param dict build_log:
+        :return bool:
+        """
         start = time.time()
         GlobalSettings.logger.debug(f"Deploying, build log: {json.dumps(build_log)[:256]} …")
 

--- a/door43_tools/templaters.py
+++ b/door43_tools/templaters.py
@@ -11,19 +11,6 @@ from general_tools.file_utils import load_yaml_object
 
 
 
-# # This resource_type map is used to set the html body class
-# #   so it must match the css in door43.org/_site/css/project-page.css
-# RESOURCE_CLASS_MAP = {'Open_BibleStories':'obs',
-#                         'Translation_Academy':'ta',
-#                         'Translation_Questions':'tq', 'OBS_Translation_Questions':'tq', 'obs_tq':'tq',
-#                         'Translation_Words':'tw',
-#                         'Translation_Notes':'tn', 'OBS_Translation_Notes':'tn', 'obs_tn':'tn',
-#                         'Bible':'bible', 'Aligned_Bible':'bible',
-#                             'Greek_New_Testament':'bible', 'Hebrew_Old_Testament':'bible',
-#                         }
-
-
-
 def do_template(resource_type, source_dir, output_dir, template_file):
     """
     Only used by test_templaters.py
@@ -74,10 +61,6 @@ class Templater:
         self.resource_type = resource_type
         # This templater_CSS_class is used to set the html body class
         #   so it must match the css in door43.org/_site/css/project-page.css
-        # try:
-        #     self.templater_CSS_class = RESOURCE_CLASS_MAP[resource_type]
-        # except KeyError:
-        #     self.templater_CSS_class = resource_type
         assert self.templater_CSS_class # Must be set by subclass
         GlobalSettings.logger.info(f'Using {self.templater_CSS_class} templater…')
         if self.templater_CSS_class not in ('obs','ta','tq','tw','tn','bible'):
@@ -100,7 +83,7 @@ class Templater:
 
     def run(self):
         # GlobalSettings.logger.debug("Templater.run()")
-        # get the resource container
+        # Get the resource container
         self.rc = RC(self.source_dir)
         with open(self.template_file) as template_file:
             self.template_html = template_file.read()

--- a/tests/door43_tools_tests/test_project_deployer.py
+++ b/tests/door43_tools_tests/test_project_deployer.py
@@ -41,34 +41,34 @@ class ProjectDeployerTests(unittest.TestCase):
     def tearDown(self):
         rmtree(self.temp_dir, ignore_errors=True)
 
-    def test_obs_deploy_revision_to_door43(self):
+    def test_obs_download_buildlog_and_deploy_revision_to_door43(self):
         self.mock_s3_obs_project()
         build_log_key = '{0}/build_log.json'.format(self.project_key)
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
         self.assertTrue(ret)
         self.assertTrue(GlobalSettings.door43_s3_handler().key_exists(build_log_key))
         self.assertTrue(GlobalSettings.door43_s3_handler().key_exists('{0}/50.html'.format(self.project_key)))
 
-    def test_obs_deploy_revision_to_door43_exception(self):
+    def test_obs_download_buildlog_and_deploy_revision_to_door43_exception(self):
         self.mock_s3_obs_project()
         build_log_key = '{0}/build_log.json'.format(self.project_key)
         self.deployer.run_templater = self.mock_run_templater_exception
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
         self.assertFalse(ret)
 
-    def test_bad_deploy_revision_to_door43(self):
+    def test_bad_download_buildlog_and_deploy_revision_to_door43(self):
         self.mock_s3_obs_project()
         bad_key = 'u/test_user/test_repo/12345678/bad_build_log.json'
-        ret = self.deployer.deploy_revision_to_door43(bad_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(bad_key)
         self.assertFalse(ret)
 
-    def test_tq_deploy_revision_to_door43(self):
+    def test_tq_download_buildlog_and_deploy_revision_to_door43(self):
         # given
         self.mock_s3_tq_project()
         build_log_key = '{0}/build_log.json'.format(self.project_key)
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.assertTrue(ret)
@@ -86,10 +86,10 @@ class ProjectDeployerTests(unittest.TestCase):
             key = '{0}/{1}'.format(parent_key, file_name)
             self.assertTrue(GlobalSettings.door43_s3_handler().key_exists(key), "Key not found: {0}".format(key))
 
-    def test_tw_deploy_revision_to_door43(self):
+    def test_tw_download_buildlog_and_deploy_revision_to_door43(self):
         self.mock_s3_tw_project()
         build_log_key = '{0}/build_log.json'.format(self.project_key)
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
         self.assertTrue(ret)
         self.assertTrue(GlobalSettings.door43_s3_handler().key_exists(build_log_key))
         for file_name in ['index.html', 'kt.html', 'names.html', 'other.html', 'build_log.json', 'manifest.yaml']:
@@ -100,14 +100,14 @@ class ProjectDeployerTests(unittest.TestCase):
             key = '{0}/{1}'.format(parent_key, file_name)
             self.assertTrue(GlobalSettings.door43_s3_handler().key_exists(key), "Key not found: {0}".format(key))
 
-    def test_tn_deploy_revision_to_door43(self):
+    def test_tn_download_buildlog_and_deploy_revision_to_door43(self):
         # given
         part = '1'
         self.mock_s3_tn_project(part)
         build_log_key = '{0}/{1}/build_log.json'.format(self.project_key, part)
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.assertTrue(ret)
@@ -130,7 +130,7 @@ class ProjectDeployerTests(unittest.TestCase):
         expect_success = True
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.validate_bible_results(ret, build_log_key, expect_success, output_key)
@@ -145,7 +145,7 @@ class ProjectDeployerTests(unittest.TestCase):
         self.deployer.run_templater = self.mock_run_templater_exception
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.assertFalse(ret)
@@ -160,7 +160,7 @@ class ProjectDeployerTests(unittest.TestCase):
         expect_success = False
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.validate_bible_results(ret, build_log_key, expect_success, None)
@@ -175,7 +175,7 @@ class ProjectDeployerTests(unittest.TestCase):
         expect_success = True
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.validate_bible_results(ret, build_log_key, expect_success, None)
@@ -192,7 +192,7 @@ class ProjectDeployerTests(unittest.TestCase):
         output_key = '{0}/{1}'.format(self.project_key, output_file)
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.validate_bible_results(ret, build_log_key, expect_success, output_key)
@@ -206,7 +206,7 @@ class ProjectDeployerTests(unittest.TestCase):
         self.deployer.run_templater = self.mock_run_templater_exception
 
         # when
-        ret = self.deployer.deploy_revision_to_door43(build_log_key)
+        ret = self.deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
 
         # then
         self.assertFalse(ret)

--- a/webhook.py
+++ b/webhook.py
@@ -39,8 +39,8 @@ KNOWN_RESOURCE_SUBJECTS = ('Bible', 'Aligned_Bible', 'Greek_New_Testament', 'Heb
 # TODO: Will we also need 'book' in this map???
 RESOURCE_SUBJECT_MAP = {
             'obs': 'Open_Bible_Stories',
-            'obs_tn': 'OBS_Translation_Notes', 'obs-tn': 'OBS_Translation_Notes',
-            'obs_tq': 'OBS_Translation_Questions', 'obs-tq': 'OBS_Translation_Questions',
+            'obs-tn': 'OBS_Translation_Notes',
+            'obs-tq': 'OBS_Translation_Questions',
 
             'ta': 'Translation_Academy',
             'tn': 'Translation_Notes',
@@ -500,10 +500,19 @@ def process_job(queued_json_payload, redis_connection):
     if not resource_type and rc.resource.type in RESOURCE_SUBJECT_MAP: # e.g., help, man
         GlobalSettings.logger.debug(f"Using rc.resource.type='{rc.resource.type}' to set resource_type={RESOURCE_SUBJECT_MAP[rc.resource.type]}")
         resource_type = RESOURCE_SUBJECT_MAP[rc.resource.type]
+
     input_format = rc.resource.file_ext
+    if resource_type in ('Bible', 'Aligned_Bible', 'Greek_New_Testament', 'Hebrew_Old_Testament',) \
+    and input_format not in ('usfm','usfm3',):
+        # This can happen for usfm in .txt files (ts-desktop exports)
+        use_logger = GlobalSettings.logger.warning if input_format=='txt' else GlobalSettings.logger.critical
+        use_logger(f"Changing input_format from '{input_format}' to 'usfm' for  resource_type={resource_type}")
+        input_format = 'usfm'
+
+    # Summarize
     GlobalSettings.logger.info(f"Got resource_type={resource_type}, input_format={input_format}")
     if resource_type not in KNOWN_RESOURCE_SUBJECTS:
-        GlobalSettings.logger.error(f"Got unexpected resource_type={resource_type} with input_format={input_format}")
+        GlobalSettings.logger.critical(f"Got unexpected resource_type={resource_type} with input_format={input_format}")
     assert resource_type and input_format # Might as well fail here if they're not set properly
 
 

--- a/webhook.py
+++ b/webhook.py
@@ -38,6 +38,7 @@ KNOWN_RESOURCE_SUBJECTS = ('Bible', 'Aligned_Bible', 'Greek_New_Testament', 'Heb
             # A similar table also exists in tx-enqueue-job:check_posted_tx_payload.py
 # TODO: Will we also need 'book' in this map???
 RESOURCE_SUBJECT_MAP = {
+            # Maps from rc.resource.identifier and possibly also from rc.resource.type
             'obs': 'Open_Bible_Stories',
             'obs-tn': 'OBS_Translation_Notes',
             'obs-tq': 'OBS_Translation_Questions',
@@ -480,7 +481,7 @@ def process_job(queued_json_payload, redis_connection):
     if adjusted_subject in KNOWN_RESOURCE_SUBJECTS:
         GlobalSettings.logger.debug(f"Using (adjusted) subject to set resource_type={adjusted_subject}")
         resource_type = adjusted_subject
-    elif 'bible' in adjusted_subject.lower():
+    elif 'bible' in adjusted_subject.lower() and rc.resource.identifier not in RESOURCE_SUBJECT_MAP:
         GlobalSettings.logger.debug(f"Using 'bible' in (adjusted) subject=={adjusted_subject} to set resource_type")
         resource_type = 'Bible'
     else:


### PR DESCRIPTION
Handles ts-desktop exported Bibles with usfm in .txt files

Fixes a problem in subject detection where "Bible Translation Questions" was mishandled (as Bible not Translation Questions).

Other small tweaks and improvements.

NOTE: en_ugl and en_ugc now cause a failure (rather than just silently failing to convert).