### PR TITLE
Remove unnecessary uploads and downloads

### DIFF
--- a/callback.py
+++ b/callback.py
@@ -97,6 +97,7 @@ def merge_results_logs(build_log, file_results, linter_file):
     if not build_log:
         return file_results
     if file_results:
+        merge_dicts_lists(build_log, file_results, 'message')
         merge_dicts_lists(build_log, file_results, 'log')
         merge_dicts_lists(build_log, file_results, 'warnings')
         merge_dicts_lists(build_log, file_results, 'errors')

--- a/callback.py
+++ b/callback.py
@@ -291,7 +291,7 @@ def process_callback_job(pc_prefix, queued_json_payload, redis_connection):
 
     # Now deploy the new pages (was previously a separate AWS Lambda call)
     GlobalSettings.logger.info(f"Deploying to the website (convert status='{final_build_log['status']}')…")
-    deployer = ProjectDeployer(our_temp_dir, unzip_dir)
+    deployer = ProjectDeployer(unzip_dir, our_temp_dir)
     # build_log_key = f'{url_part2}/build_log.json'
     # GlobalSettings.logger.debug(f"Got {GlobalSettings.cdn_bucket_name} build_log_key={build_log_key}")
     # deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)

--- a/callback.py
+++ b/callback.py
@@ -7,8 +7,9 @@
 # Python imports
 import os
 from datetime import datetime
-from time import time
+import time
 from ast import literal_eval
+import tempfile
 import traceback
 
 # Library (PyPi) imports
@@ -21,6 +22,7 @@ from global_settings.global_settings import GlobalSettings
 from client_converter_callback import ClientConverterCallback
 from client_linter_callback import ClientLinterCallback
 from door43_tools.project_deployer import ProjectDeployer
+from general_tools.file_utils import write_file, remove_tree
 
 
 
@@ -75,6 +77,102 @@ def verify_expected_job(vej_job_dict, vej_redis_connection):
 # end of verify_expected_job
 
 
+# def upload_build_log(build_log, file_name, output_dir, s3_results_key, cache_time=0):
+#     GlobalSettings.logger.debug(f"ClientLinterCallback.upload_build_log(…, {file_name}, {output_dir}, {s3_results_key}, {cache_time})…")
+#     build_log_filepath = os.path.join(output_dir, file_name)
+#     write_file(build_log_filepath, build_log)
+#     upload_key = f'{s3_results_key}/{file_name}'
+#     GlobalSettings.logger.debug(f"Uploading build log to {GlobalSettings.cdn_bucket_name}/{upload_key} …")
+#     GlobalSettings.cdn_s3_handler().upload_file(build_log_filepath, upload_key, cache_time=cache_time)
+# # end of upload_build_log function
+
+
+def merge_results_logs(build_log, file_results, linter_file):
+    """
+    Given a second partial build log file_results,
+        combine the log/warnings/errors lists into the first build_log.
+    """
+    assert not linter_file
+    GlobalSettings.logger.debug(f"Callback.merge_results_logs(…, {file_results}, {linter_file})…")
+    if not build_log:
+        return file_results
+    if file_results:
+        merge_dicts_lists(build_log, file_results, 'log')
+        merge_dicts_lists(build_log, file_results, 'warnings')
+        merge_dicts_lists(build_log, file_results, 'errors')
+        if not linter_file and ('success' in file_results) and (file_results['success'] is False):
+            build_log['success'] = file_results['success']
+    return build_log
+# end of merge_results_logs function
+
+
+def merge_dicts_lists(build_log, file_results, key):
+    """
+    Used for merging log dicts from various sub-processes.
+
+    build_log is a dict
+    file_results is a dict
+    value is a key (string) for the lists that will be merged if in both dicts
+
+    Alters first parameter build_log in place.
+    """
+    GlobalSettings.logger.debug(f"Callback.merge_dicts({build_log}, {file_results}, '{key}')…")
+    if key in file_results:
+        value = file_results[key]
+        if value:
+            if (key in build_log) and (build_log[key]):
+                build_log[key] += value
+            else:
+                build_log[key] = value
+# end of merge_dicts_lists function
+
+
+# TODO: Is this really needed? What uses it?
+def update_project_file(build_log, output_dir=None):
+    GlobalSettings.logger.debug(f"Callback.update_project_file({build_log}, output_dir={output_dir})…")
+    if not output_dir:
+        output_dir = tempfile.mkdtemp(suffix='',
+                     prefix='Door43_callback_deploy_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+
+    commit_id = build_log['commit_id']
+    user_name = build_log['repo_owner']
+    repo_name = build_log['repo_name']
+    project_json_key = f'u/{user_name}/{repo_name}/project.json'
+    project_json = GlobalSettings.cdn_s3_handler().get_json(project_json_key)
+    project_json['user'] = user_name
+    project_json['repo'] = repo_name
+    project_json['repo_url'] = f'https://{GlobalSettings.gogs_url}/{user_name}/{repo_name}'
+    commit = {
+        'id': commit_id,
+        'created_at': build_log['created_at'],
+        'status': build_log['status'],
+        'success': build_log['success'],
+        'started_at': None,
+        'ended_at': None
+    }
+    if 'started_at' in build_log:
+        commit['started_at'] = build_log['started_at']
+    if 'ended_at' in build_log:
+        commit['ended_at'] = build_log['ended_at']
+    if 'commits' not in project_json:
+        project_json['commits'] = []
+    commits = []
+    for c in project_json['commits']:
+        if c['id'] != commit_id:
+            commits.append(c)
+    commits.append(commit)
+    project_json['commits'] = commits
+    project_file = os.path.join(output_dir, 'project.json')
+    write_file(project_file, project_json)
+    GlobalSettings.cdn_s3_handler().upload_file(project_file, project_json_key, cache_time=0)
+    if prefix and debug_mode_flag:
+        GlobalSettings.logger.debug(f"Temp folder '{output_dir}' has been left on disk for debugging!")
+    else:
+        remove_tree(output_dir)
+    return project_json
+# end of update_project_file function
+
+
 # user_projects_invoked_string = 'user-projects.invoked.unknown--unknown'
 def process_callback_job(pc_prefix, queued_json_payload, redis_connection):
     """
@@ -110,11 +208,12 @@ def process_callback_job(pc_prefix, queued_json_payload, redis_connection):
     matched_job_dict = verify_result
     GlobalSettings.logger.debug(f"Got matched_job_dict: {matched_job_dict}")
     job_descriptive_name = f"{queued_json_payload['resource_type']}({queued_json_payload['input_format']})"
-
+    if 'repo_owner' not in matched_job_dict: # Why did we have to add this?
+        matched_job_dict['repo_owner'] = matched_job_dict['user_name'] # Where did it used to be done/gotten from?
 
     this_job_dict = queued_json_payload.copy()
     # Get needed fields that we saved but didn't submit to tX
-    for fieldname in ('user_name', 'repo_name', 'commit_id',):
+    for fieldname in ('user_name', 'repo_name', 'commit_id'):
         assert fieldname not in this_job_dict
         this_job_dict[fieldname] = matched_job_dict[fieldname]
 
@@ -146,6 +245,10 @@ def process_callback_job(pc_prefix, queued_json_payload, redis_connection):
     #                     if 'user_projects_invoked_string' in matched_job_dict \
     #                     else f'??{identifier}??'
 
+    matched_job_dict['log'] = []
+    matched_job_dict['warnings'] = []
+    matched_job_dict['errors'] = []
+
     # We get the tx-manager existing calls to do our work for us
     # It doesn't actually matter which one we do first I think
     GlobalSettings.logger.info("Running linter post-processing…")
@@ -155,25 +258,46 @@ def process_callback_job(pc_prefix, queued_json_payload, redis_connection):
                                queued_json_payload['linter_info'] if 'linter_info' in queued_json_payload else None,
                                queued_json_payload['linter_warnings'],
                                queued_json_payload['linter_errors'] if 'linter_errors' in queued_json_payload else None,
-                               s3_results_key=url_part2)
-    # clc_build_log = clc.do_post_processing() # We don't use the result
-    clc.do_post_processing()
+                                )
+                            #    s3_results_key=url_part2)
+    linter_log = clc.do_post_processing()
+    build_log = merge_results_logs(matched_job_dict, linter_log, linter_file=False) # What is the last parameter for?
     GlobalSettings.logger.info("Running converter post-processing…")
     ccc = ClientConverterCallback(this_job_dict, identifier,
                                   queued_json_payload['converter_success'],
                                   queued_json_payload['converter_info'],
                                   queued_json_payload['converter_warnings'],
                                   queued_json_payload['converter_errors'])
-    ccc_build_log = ccc.do_post_processing()
-    final_build_log = ccc_build_log
+    unzip_dir, converter_log = ccc.do_post_processing()
+    # deploy_if_conversion_finished(url_part2, identifier)
+    final_build_log = merge_results_logs(build_log, converter_log, linter_file=False) # What is the last parameter for?
+
+    if final_build_log['errors']:
+        final_build_log['status'] = 'errors'
+    elif final_build_log['warnings']:
+        final_build_log['status'] = 'warnings'
+    else:
+        final_build_log['status'] = 'success'
+        final_build_log['success'] = True
+    final_build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    output_dir = tempfile.mkdtemp(suffix='',
+                     prefix='Door43_callback_deploy_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+    update_project_file(final_build_log, output_dir)
+    # NOTE: The following is disabled coz it's done (again) later by the deployer
+    # upload_build_log(final_build_log, 'build_log.json', output_dir, url_part2, cache_time=600)
+    if prefix and debug_mode_flag:
+        GlobalSettings.logger.debug(f"Temp folder '{output_dir}' has been left on disk for debugging!")
+    else:
+        remove_tree(output_dir)
 
     # Now deploy the new pages (was previously a separate AWS Lambda call)
     GlobalSettings.logger.info(f"Deploying to the website (convert status='{final_build_log['status']}')…")
-    deployer = ProjectDeployer()
+    deployer = ProjectDeployer(unzip_dir)
     # build_log_key = f'{url_part2}/build_log.json'
     # GlobalSettings.logger.debug(f"Got {GlobalSettings.cdn_bucket_name} build_log_key={build_log_key}")
     # deployer.download_buildlog_and_deploy_revision_to_door43(build_log_key)
-    deployer.deploy_revision_to_door43(final_build_log) # No need to download the build log since we have it here
+    # No need to download the build log since we have it here
+    deployer.deploy_revision_to_door43(final_build_log)
 
     # Finishing off
     str_final_build_log = str(final_build_log)
@@ -196,7 +320,7 @@ def job(queued_json_payload):
             then the job gets added to the 'failed' queue.
     """
     GlobalSettings.logger.info("Door43-Job-Handler received a callback" + (" (in debug mode)" if debug_mode_flag else ""))
-    start_time = time()
+    start_time = time.time()
     stats_client.incr(f'{stats_prefix}.callback.jobs.attempted')
 
     current_job = get_current_job()
@@ -246,12 +370,12 @@ def job(queued_json_payload):
         # stats_client.gauge(user_projects_invoked_string, 1) # Mark as 'failed'
         raise e # We raise the exception again so it goes into the failed queue
 
-    elapsed_milliseconds = round((time() - start_time) * 1000)
+    elapsed_milliseconds = round((time.time() - start_time) * 1000)
     stats_client.timing(f'{stats_prefix}.callback.job.duration', elapsed_milliseconds)
     if elapsed_milliseconds < 2000:
         GlobalSettings.logger.info(f"{prefix}Door43 callback handling for {job_descriptive_name} completed in {elapsed_milliseconds:,} milliseconds.")
     else:
-        GlobalSettings.logger.info(f"{prefix}Door43 callback handling for {job_descriptive_name} completed in {round(time() - start_time)} seconds.")
+        GlobalSettings.logger.info(f"{prefix}Door43 callback handling for {job_descriptive_name} completed in {round(time.time() - start_time)} seconds.")
 
     # Calculate total elapsed time for the job
     total_elapsed_time = datetime.utcnow() - \

--- a/client_converter_callback.py
+++ b/client_converter_callback.py
@@ -6,7 +6,7 @@ from rq_settings import prefix, debug_mode_flag
 from global_settings.global_settings import GlobalSettings
 from general_tools.file_utils import unzip, write_file, remove_tree, remove
 from general_tools.url_utils import download_file
-from client_linter_callback import ClientLinterCallback
+# from client_linter_callback import ClientLinterCallback
 
 
 
@@ -49,6 +49,7 @@ class ClientConverterCallback:
         :param list warnings:
         :param list errors:
         """
+        GlobalSettings.logger.debug(f"ClientConverterCallback.__init__({job_dict}, id={identifier}, s={success}, i={info}, w={warnings}, e={errors})…")
         self.job = LocalJob(job_dict)
         self.identifier = identifier
         self.success = success
@@ -67,6 +68,7 @@ class ClientConverterCallback:
                             prefix='Door43_converter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
 
     def do_post_processing(self):
+        GlobalSettings.logger.debug(f"ClientConverterCallback.do_post_processing()…")
         self.job.ended_at = datetime.utcnow()
         self.job.success = self.success
         for message in self.log:
@@ -101,7 +103,8 @@ class ClientConverterCallback:
         self.job.log_message(f"Finished job {self.job.job_id} at {self.job.ended_at.strftime('%Y-%m-%dT%H:%M:%SZ')}")
 
         s3_commit_key = f'u/{self.job.user_name}/{self.job.repo_name}/{self.job.commit_id}'
-        upload_key = s3_commit_key
+        # NOTE: Disabled 4Mar2019 coz unused
+        # upload_key = s3_commit_key
         GlobalSettings.logger.debug(f"Callback for commit {s3_commit_key} …")
 
         # Download the ZIP file of the converted files
@@ -136,28 +139,34 @@ class ClientConverterCallback:
             unzip_dir = self.unzip_converted_files(converted_zip_file)
 
             # TODO: Do we really need this now?
+            # NOTE: Do we need this -- disabled 25Feb2019
             # Upload all files to the cdn_bucket with the key of <user>/<repo_name>/<commit> of the repo
-            self.upload_converted_files(upload_key, unzip_dir)
+            # self.upload_converted_files(upload_key, unzip_dir)
 
         # TODO: Do we really need this now?
         # Now download the existing build_log.json file, update it and upload it back to S3 as convert_log
-        build_log_json = self.update_convert_log(s3_commit_key)
-        self.cdn_upload_contents({}, s3_commit_key + '/finished')  # flag finished
+        # NOTE: Do we need this -- disabled 25Feb2019
+        # build_log_json = self.update_convert_log(s3_commit_key)
+        # self.cdn_upload_contents({}, s3_commit_key + '/finished')  # flag finished
+        converter_build_log = self.make_our_build_log()
+        print("Got ConPP converter_build_log", converter_build_log)
 
-        results = ClientLinterCallback.deploy_if_conversion_finished(s3_commit_key, self.identifier)
-        if results:
-            self.all_parts_completed = True
-            build_log_json = results
+        # NOTE: Disabled 4Mar2019 coz moved to callback.py
+        # results = ClientLinterCallback.deploy_if_conversion_finished(s3_commit_key, self.identifier)
+        # if results:
+        #     self.all_parts_completed = True
+        #     build_log_json = results
 
         if prefix and debug_mode_flag:
             GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
         else:
             remove_tree(self.temp_dir)  # cleanup
-        return build_log_json
+        return unzip_dir, converter_build_log
     # end of do_post_processing()
 
 
     def unzip_converted_files(self, converted_zip_file):
+        GlobalSettings.logger.debug(f"ClientConverterCallback.unzip_converted_files({converted_zip_file})…")
         unzip_dir = tempfile.mkdtemp(prefix='unzip_', dir=self.temp_dir)
         try:
             GlobalSettings.logger.debug(f"Unzipping {converted_zip_file} …")
@@ -179,49 +188,83 @@ class ClientConverterCallback:
                 GlobalSettings.cdn_s3_handler().upload_file(filepath, key, cache_time=0)
 
 
-    def update_convert_log(self, s3_base_key, part=''):
-        build_log_json = self.get_build_log(s3_base_key, part)
-        self.upload_convert_log(build_log_json, s3_base_key, part)
-        return build_log_json
+    # NOTE: Do we need this -- disabled 25Feb2019
+    # def update_convert_log(self, s3_base_key, part=''):
+    #     build_log_json = self.get_build_log(s3_base_key, part)
+    #     self.upload_convert_log(build_log_json, s3_base_key, part)
+    #     return build_log_json
 
 
-    def upload_convert_log(self, build_log_json, s3_base_key, part=''):
+    def make_our_build_log(self):
+        build_log_dict = {}
         if self.job.started_at:
-            build_log_json['started_at'] = self.job.started_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+            build_log_dict['started_at'] = self.job.started_at.strftime('%Y-%m-%dT%H:%M:%SZ')
         else:
-            build_log_json['started_at'] = None
+            build_log_dict['started_at'] = None
         if self.job.ended_at:
-            build_log_json['ended_at'] = self.job.ended_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+            build_log_dict['ended_at'] = self.job.ended_at.strftime('%Y-%m-%dT%H:%M:%SZ')
         else:
-            build_log_json['ended_at'] = None
-        build_log_json['success'] = self.job.success
-        build_log_json['status'] = self.job.status
-        build_log_json['message'] = self.job.message
+            build_log_dict['ended_at'] = None
+        build_log_dict['success'] = self.job.success
+        build_log_dict['status'] = self.job.status
+        build_log_dict['message'] = self.job.message
         if self.job.log:
-            build_log_json['log'] = self.job.log
+            build_log_dict['log'] = self.job.log
         else:
-            build_log_json['log'] = []
+            build_log_dict['log'] = []
         if self.job.warnings:
-            build_log_json['warnings'] = self.job.warnings
+            build_log_dict['warnings'] = self.job.warnings
         else:
-            build_log_json['warnings'] = []
+            build_log_dict['warnings'] = []
         if self.job.errors:
-            build_log_json['errors'] = self.job.errors
+            build_log_dict['errors'] = self.job.errors
         else:
-            build_log_json['errors'] = []
-        build_log_key = self.get_build_log_key(s3_base_key, part, name='convert_log.json')
-        GlobalSettings.logger.debug(f"Uploading build log to S3:{GlobalSettings.cdn_bucket_name}/{build_log_key} …")
-        # GlobalSettings.logger.debug('build_log contents: ' + json.dumps(build_log_json))
-        self.cdn_upload_contents(build_log_json, build_log_key)
-        return build_log_json
+            build_log_dict['errors'] = []
+        return build_log_dict
+    #end of make_our_build_log()
+
+
+    # NOTE: Do we need this -- disabled 25Feb2019
+    # def upload_convert_log(self, build_log_json, s3_base_key, part=''):
+    #     if self.job.started_at:
+    #         build_log_json['started_at'] = self.job.started_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+    #     else:
+    #         build_log_json['started_at'] = None
+    #     if self.job.ended_at:
+    #         build_log_json['ended_at'] = self.job.ended_at.strftime('%Y-%m-%dT%H:%M:%SZ')
+    #     else:
+    #         build_log_json['ended_at'] = None
+    #     build_log_json['success'] = self.job.success
+    #     build_log_json['status'] = self.job.status
+    #     build_log_json['message'] = self.job.message
+    #     if self.job.log:
+    #         build_log_json['log'] = self.job.log
+    #     else:
+    #         build_log_json['log'] = []
+    #     if self.job.warnings:
+    #         build_log_json['warnings'] = self.job.warnings
+    #     else:
+    #         build_log_json['warnings'] = []
+    #     if self.job.errors:
+    #         build_log_json['errors'] = self.job.errors
+    #     else:
+    #         build_log_json['errors'] = []
+    #     build_log_key = self.get_build_log_key(s3_base_key, part, name='convert_log.json')
+    #     GlobalSettings.logger.debug(f"Uploading build log to S3:{GlobalSettings.cdn_bucket_name}/{build_log_key} …")
+    #     # GlobalSettings.logger.debug('build_log contents: ' + json.dumps(build_log_json))
+    #     self.cdn_upload_contents(build_log_json, build_log_key)
+    #     return build_log_json
 
     def cdn_upload_contents(self, contents, key):
+        GlobalSettings.logger.debug(f"ClientConverterCallback.cdn_upload_contents({contents}, {key})…")
         file_name = os.path.join(self.temp_dir, 'contents.json')
         write_file(file_name, contents)
         GlobalSettings.logger.debug(f"Uploading file to S3:{GlobalSettings.cdn_bucket_name}/{key} …")
         GlobalSettings.cdn_s3_handler().upload_file(file_name, key, cache_time=0)
 
     def get_build_log(self, s3_base_key, part=''):
+        GlobalSettings.logger.debug(f"ClientConverterCallback.get_build_log({s3_base_key}, {part})…")
+        assert not part
         build_log_key = self.get_build_log_key(s3_base_key, part)
         # GlobalSettings.logger.debug('Reading build log from ' + build_log_key)
         build_log_json = GlobalSettings.cdn_s3_handler().get_json(build_log_key)
@@ -230,5 +273,7 @@ class ClientConverterCallback:
 
     @staticmethod
     def get_build_log_key(s3_base_key, part='', name='build_log.json'):
+        assert not part
+        GlobalSettings.logger.debug(f"ClientConverterCallback.get_build_log_key({s3_base_key}, {part}, {name})…")
         upload_key = f'{s3_base_key}/{part}{name}'
         return upload_key

--- a/client_converter_callback.py
+++ b/client_converter_callback.py
@@ -41,7 +41,7 @@ class LocalJob:
 
 class ClientConverterCallback:
 
-    def __init__(self, job_dict, identifier, success, info, warnings, errors):
+    def __init__(self, job_dict, identifier, success, info, warnings, errors, output_dir):
         """
         :param string identifier:
         :param bool success:
@@ -49,13 +49,14 @@ class ClientConverterCallback:
         :param list warnings:
         :param list errors:
         """
-        GlobalSettings.logger.debug(f"ClientConverterCallback.__init__({job_dict}, id={identifier}, s={success}, i={info}, w={warnings}, e={errors})…")
+        GlobalSettings.logger.debug(f"ClientConverterCallback.__init__({job_dict}, id={identifier}, s={success}, i={info}, w={warnings}, e={errors}, od={output_dir})…")
         self.job = LocalJob(job_dict)
         self.identifier = identifier
         self.success = success
         self.log = info
         self.warnings = warnings
         self.errors = errors
+        self.temp_dir = output_dir
         self.all_parts_completed = False
 
         if not self.log:
@@ -64,8 +65,9 @@ class ClientConverterCallback:
             self.warnings = []
         if not self.errors:
             self.errors = []
-        self.temp_dir = tempfile.mkdtemp(suffix='',
-                            prefix='Door43_converter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+        # self.temp_dir = tempfile.mkdtemp(suffix='',
+        #                     prefix='Door43_converter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+
 
     def do_post_processing(self):
         GlobalSettings.logger.debug(f"ClientConverterCallback.do_post_processing()…")
@@ -173,8 +175,8 @@ class ClientConverterCallback:
             unzip(converted_zip_file, unzip_dir)
         finally:
             GlobalSettings.logger.debug("Unzip finished.")
-
         return unzip_dir
+    # end of unzip_converted_files function
 
 
     @staticmethod

--- a/client_converter_callback.py
+++ b/client_converter_callback.py
@@ -120,10 +120,10 @@ class ClientConverterCallback:
         except:
             download_success = False  # if multiple project we note fail and move on
             # if not multiple_project:
-            if prefix and debug_mode_flag:
-                GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
-            else:
-                remove_tree(self.temp_dir)  # cleanup
+            # if prefix and debug_mode_flag:
+            #     GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
+            # else:
+            #     remove_tree(self.temp_dir)  # cleanup
             if self.job.errors is None:
                 self.job.errors = []
             message = f"Missing converted file: {converted_zip_url}"
@@ -159,10 +159,10 @@ class ClientConverterCallback:
         #     self.all_parts_completed = True
         #     build_log_json = results
 
-        if prefix and debug_mode_flag:
-            GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
-        else:
-            remove_tree(self.temp_dir)  # cleanup
+        # if prefix and debug_mode_flag:
+        #     GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
+        # else:
+        #     remove_tree(self.temp_dir)  # cleanup
         return unzip_dir, converter_build_log
     # end of do_post_processing()
 

--- a/client_converter_callback.py
+++ b/client_converter_callback.py
@@ -149,7 +149,7 @@ class ClientConverterCallback:
         # build_log_json = self.update_convert_log(s3_commit_key)
         # self.cdn_upload_contents({}, s3_commit_key + '/finished')  # flag finished
         converter_build_log = self.make_our_build_log()
-        print("Got ConPP converter_build_log", converter_build_log)
+        # print("Got ConPP converter_build_log", converter_build_log)
 
         # NOTE: Disabled 4Mar2019 coz moved to callback.py
         # results = ClientLinterCallback.deploy_if_conversion_finished(s3_commit_key, self.identifier)
@@ -196,6 +196,7 @@ class ClientConverterCallback:
 
 
     def make_our_build_log(self):
+        GlobalSettings.logger.debug(f"ClientConverterCallback.make_our_build_log()…")
         build_log_dict = {}
         if self.job.started_at:
             build_log_dict['started_at'] = self.job.started_at.strftime('%Y-%m-%dT%H:%M:%SZ')
@@ -221,7 +222,7 @@ class ClientConverterCallback:
         else:
             build_log_dict['errors'] = []
         return build_log_dict
-    #end of make_our_build_log()
+    # end of make_our_build_log()
 
 
     # NOTE: Do we need this -- disabled 25Feb2019

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -42,8 +42,8 @@ class ClientLinterCallback:
             self.warnings = []
         if not self.errors:
             self.errors = []
-        self.temp_dir = tempfile.mkdtemp(suffix='',
-                            prefix='Door43_linter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+        # self.temp_dir = tempfile.mkdtemp(suffix='',
+        #                     prefix='Door43_linter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
         # self.s3_results_key = s3_results_key
         self.job = None
 
@@ -108,10 +108,10 @@ class ClientLinterCallback:
         #     self.all_parts_completed = True
         #     build_log = results
 
-        if prefix and debug_mode_flag:
-            GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
-        else:
-            remove_tree(self.temp_dir)  # cleanup
+        # if prefix and debug_mode_flag:
+        #     GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
+        # else:
+        #     remove_tree(self.temp_dir)  # cleanup
         GlobalSettings.db_close()
         return build_log
     # end of do_post_processing()

--- a/client_linter_callback.py
+++ b/client_linter_callback.py
@@ -11,7 +11,7 @@ from general_tools.file_utils import write_file, remove_tree
 
 class ClientLinterCallback:
 
-    def __init__(self, job_dict, identifier, success, info, warnings, errors, s3_results_key):
+    def __init__(self, job_dict, identifier, success, info, warnings, errors): #, s3_results_key):
         """
         :param identifier: either
                     job_id/part_count/part_id/book if multi-part job
@@ -26,6 +26,7 @@ class ClientLinterCallback:
                         or
                     u/user/repo/commid_id/part_id if multi-part job
         """
+        GlobalSettings.logger.debug(f"ClientLinterCallback.__init__({job_dict}, id={identifier}, s={success}, i={info}, w={warnings}, e={errors})…")
         self.job_dict = job_dict
         self.identifier = identifier
         self.success = success
@@ -43,30 +44,34 @@ class ClientLinterCallback:
             self.errors = []
         self.temp_dir = tempfile.mkdtemp(suffix='',
                             prefix='Door43_linter_callback_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
-        self.s3_results_key = s3_results_key
+        # self.s3_results_key = s3_results_key
         self.job = None
 
     def do_post_processing(self):
+        GlobalSettings.logger.debug(f"ClientLinterCallback.do_post_processing()…")
         if not self.identifier:
             error = 'No identifier found'
             GlobalSettings.logger.error(error)
             raise Exception(error)
 
-        if not self.s3_results_key:
-            error = f"No s3_results_key found for identifier = {self.identifier}"
-            GlobalSettings.logger.error(error)
-            raise Exception(error)
+        # if not self.s3_results_key:
+        #     error = f"No s3_results_key found for identifier = {self.identifier}"
+        #     GlobalSettings.logger.error(error)
+        #     raise Exception(error)
 
         id_parts = self.identifier.split('/')
         self.multipart = len(id_parts) > 3
         if self.multipart:
-            part_count, part_id, book = id_parts[1:4]
-            GlobalSettings.logger.debug('Multiple project, part {0} of {1}, linted book {2}'.
-                             format(part_id, part_count, book))
-            s3__master_results_key = '/'.join(self.s3_results_key.split('/')[:-1])
+            halt
+            # NOTE: Disabled 4Mar2019 coz unused
+            # part_count, part_id, book = id_parts[1:4]
+            # GlobalSettings.logger.debug('Multiple project, part {0} of {1}, linted book {2}'.
+            #                  format(part_id, part_count, book))
+            # s3__master_results_key = '/'.join(self.s3_results_key.split('/')[:-1])
         else:
             GlobalSettings.logger.debug('Single project')
-            s3__master_results_key = self.s3_results_key
+            # NOTE: Disabled 4Mar2019 coz unused
+            # s3__master_results_key = self.s3_results_key
 
         build_log = {
             'identifier': self.identifier,
@@ -75,7 +80,7 @@ class ClientLinterCallback:
             'log': self.log,
             'warnings': self.warnings,
             'errors': self.errors,
-            's3_commit_key': self.s3_results_key
+            # 's3_commit_key': self.s3_results_key
         }
 
         if not self.success:
@@ -94,12 +99,14 @@ class ClientLinterCallback:
             msg = f"Linter {self.identifier} completed with no warnings"
             build_log['log'].append(msg)
 
-        ClientLinterCallback.upload_build_log(build_log, 'lint_log.json', self.temp_dir, self.s3_results_key)
+        # NOTE: Do we need this -- disabled 25Feb2019
+        # ClientLinterCallback.upload_build_log(build_log, 'lint_log.json', self.temp_dir, self.s3_results_key)
 
-        results = ClientLinterCallback.deploy_if_conversion_finished(s3__master_results_key, self.identifier)
-        if results:
-            self.all_parts_completed = True
-            build_log = results
+        # NOTE: Do we need this -- disabled 4Mar2019 since linting is always done first
+        # results = ClientLinterCallback.deploy_if_conversion_finished(s3__master_results_key, self.identifier)
+        # if results:
+        #     self.all_parts_completed = True
+        #     build_log = results
 
         if prefix and debug_mode_flag:
             GlobalSettings.logger.debug(f"Temp folder '{self.temp_dir}' has been left on disk for debugging!")
@@ -110,222 +117,241 @@ class ClientLinterCallback:
     # end of do_post_processing()
 
 
-    @staticmethod
-    def upload_build_log(build_log, file_name, output_dir, s3_results_key, cache_time=0):
-        build_log_file = os.path.join(output_dir, file_name)
-        write_file(build_log_file, build_log)
-        upload_key = f'{s3_results_key}/{file_name}'
-        GlobalSettings.logger.debug(f"Uploading build log to {GlobalSettings.cdn_bucket_name}/{upload_key} …")
-        GlobalSettings.cdn_s3_handler().upload_file(build_log_file, upload_key, cache_time=cache_time)
+    # @staticmethod
+    # def upload_build_log(build_log, file_name, output_dir, s3_results_key, cache_time=0):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.upload_build_log({build_log}, {file_name}, {output_dir}, {s3_results_key}, {cache_time})…")
+    #     build_log_file = os.path.join(output_dir, file_name)
+    #     write_file(build_log_file, build_log)
+    #     upload_key = f'{s3_results_key}/{file_name}'
+    #     GlobalSettings.logger.debug(f"Uploading build log to {GlobalSettings.cdn_bucket_name}/{upload_key} …")
+    #     GlobalSettings.cdn_s3_handler().upload_file(build_log_file, upload_key, cache_time=cache_time)
 
 
-    @staticmethod
-    def deploy_if_conversion_finished(s3_results_key, identifier):
-        """
-        check if all parts are finished, and if so then save merged build_log as well as update jobs table
-        :param s3_results_key: format - u/user/repo/commid_id
-        :param identifier: either
-                    job_id/part_count/part_id/book if multi-part job
-                        or
-                    job_id if single job
-        :return:
-        """
-        output_dir = tempfile.mkdtemp(suffix='',
-                        prefix='Door43_callback_deploy_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
-        build_log = None
-        id_parts = identifier.split('/')
-        multiple_project = len(id_parts) > 3
-        all_parts_completed = True
+    # @staticmethod
+    # def deploy_if_conversion_finished(s3_results_key, identifier):
+    #     """
+    #     check if all parts are finished, and if so then save merged build_log as well as update jobs table
+    #     :param s3_results_key: format - u/user/repo/commid_id
+    #     :param identifier: either
+    #                 job_id/part_count/part_id/book if multi-part job
+    #                     or
+    #                 job_id if single job
+    #     :return:
+    #     """
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.deploy_if_conversion_finished({s3_results_key}, {identifier})…")
+    #     output_dir = tempfile.mkdtemp(suffix='',
+    #                     prefix='Door43_callback_deploy_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
+    #     build_log = None
+    #     id_parts = identifier.split('/')
+    #     multiple_project = len(id_parts) > 3
+    #     all_parts_completed = True
 
-        if not multiple_project:
-            GlobalSettings.logger.debug('Single job: checking if both convert and lint have completed_')
-            build_log = ClientLinterCallback.merge_build_status_for_part(build_log, s3_results_key, output_dir)
-        else:
-            GlobalSettings.logger.debug('Multiple parts: Checking if all parts completed_')
-            # job_id, part_count, part_id, book = id_parts[:4]
-            part_count = id_parts[1]
-            for i in range(0, int(part_count)):
-                part_key = f'{s3_results_key}/{i}'
-                build_log = ClientLinterCallback.merge_build_status_for_part(build_log, part_key, output_dir)
-                if build_log is None:
-                    GlobalSettings.logger.debug(f"Part {part_key} not complete.")
-                    all_parts_completed = False
+    #     if not multiple_project:
+    #         GlobalSettings.logger.debug('Single job: checking if both convert and lint have completed…')
+    #         build_log = ClientLinterCallback.merge_build_status_for_part(build_log, s3_results_key, output_dir)
+    #     else:
+    #         GlobalSettings.logger.debug('Multiple parts: Checking if all parts completed…')
+    #         # job_id, part_count, part_id, book = id_parts[:4]
+    #         part_count = id_parts[1]
+    #         for i in range(0, int(part_count)):
+    #             part_key = f'{s3_results_key}/{i}'
+    #             build_log = ClientLinterCallback.merge_build_status_for_part(build_log, part_key, output_dir)
+    #             if build_log is None:
+    #                 GlobalSettings.logger.debug(f"Part {part_key} not complete.")
+    #                 all_parts_completed = False
 
-        if all_parts_completed and build_log is not None:  # if all parts found, save build log and kick off deploy
-            # set overall status
-            if len(build_log['errors']):
-                build_log['status'] = 'errors'
-            elif len(build_log['warnings']):
-                build_log['status'] = 'warnings'
-            build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-            if multiple_project:
-                build_log['multiple'] = True
+    #     if all_parts_completed and build_log is not None:  # if all parts found, save build log and kick off deploy
+    #         # set overall status
+    #         if len(build_log['errors']):
+    #             build_log['status'] = 'errors'
+    #         elif len(build_log['warnings']):
+    #             build_log['status'] = 'warnings'
+    #         build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
+    #         if multiple_project:
+    #             build_log['multiple'] = True
 
-            ClientLinterCallback.upload_build_log(build_log, 'final_build_log.json', output_dir, s3_results_key)
-            if not multiple_project:
-                ClientLinterCallback.upload_build_log(build_log, 'build_log.json', output_dir, s3_results_key)
-            ClientLinterCallback.update_project_file(build_log, output_dir)
-            GlobalSettings.logger.debug("All parts completed.")
-        else:
-            GlobalSettings.logger.debug("Not all parts completed.")
-            remove_tree(output_dir)
-            build_log = None
+    #         ClientLinterCallback.upload_build_log(build_log, 'final_build_log.json', output_dir, s3_results_key)
+    #         if not multiple_project:
+    #             ClientLinterCallback.upload_build_log(build_log, 'build_log.json', output_dir, s3_results_key)
+    #         ClientLinterCallback.update_project_file(build_log, output_dir)
+    #         GlobalSettings.logger.debug("All parts completed.")
+    #     else:
+    #         GlobalSettings.logger.debug("Not all parts completed.")
+    #         remove_tree(output_dir)
+    #         build_log = None
 
-        if prefix and debug_mode_flag:
-            GlobalSettings.logger.debug(f"Temp folder '{output_dir}' has been left on disk for debugging!")
-        else:
-            remove_tree(output_dir)
-        return build_log
-
-
-    @staticmethod
-    def upload_logs(s3_results_key, build_log, output_dir):
-        """
-        Was update_jobs_table
-        """
-        # GlobalSettings.logger.debug(f"upload_logs({s3_results_key}, {build_log}, {output_dir})")
-        GlobalSettings.logger.info(f"Uploading final logs to S3:…/{s3_results_key} _")
-
-        job_id = build_log['job_id']
-        GlobalSettings.logger.debug('merging build_logs for job : ' + job_id)
-        build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
-
-        # Flag this part as done
-        ClientLinterCallback.upload_build_log(build_log, 'merged.json', output_dir, s3_results_key)
-        # Update build_log to start deploy of this part
-        ClientLinterCallback.upload_build_log(build_log, 'build_log.json', output_dir, s3_results_key, cache_time=600)
-        # GlobalSettings.logger.info("Deployment on AWS should automatically begin now_")
-        return
+    #     if prefix and debug_mode_flag:
+    #         GlobalSettings.logger.debug(f"Temp folder '{output_dir}' has been left on disk for debugging!")
+    #     else:
+    #         remove_tree(output_dir)
+    #     return build_log
 
 
-    @staticmethod
-    def merge_build_status_for_part(build_log, s3_results_key, output_dir):
-        """
-        merges convert and linter status for this part of conversion into build_log.  Returns None if part not finished.
-        :param output_dir:
-        :param build_log:
-        :param s3_results_key:
-        :return:
-        """
-        GlobalSettings.logger.debug(f"merge_build_status_for_part({build_log}, {s3_results_key}, {output_dir})")
+    # NOTE: disabled 4Mar2019 coz moved to callback.py
+    # @staticmethod
+    # def upload_logs(s3_results_key, build_log, output_dir):
+    #     """
+    #     Was update_jobs_table
+    #     """
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.upload_logs({s3_results_key}, {build_log}, {output_dir})…")
+    #     GlobalSettings.logger.info(f"Uploading final logs to S3:…/{s3_results_key} …")
 
-        part_build_log = ClientLinterCallback.get_results(s3_results_key, "merged.json")  # see if already merged
-        if not part_build_log:
-            convert_finished = ClientLinterCallback.is_convert_finished(s3_results_key)
-            if not convert_finished:
-                GlobalSettings.logger.debug(f"Convert not yet finished for {s3_results_key}")
-                return None
+    #     job_id = build_log['job_id']
+    #     GlobalSettings.logger.debug('merging build_logs for job : ' + job_id)
+    #     build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
 
-            part_build_log = ClientLinterCallback.get_results(s3_results_key, "convert_log.json")
-            if part_build_log:
-                part_build_log_combined = ClientLinterCallback.merge_build_status_for_file(part_build_log,
-                                                                                           s3_results_key,
-                                                                                           "lint_log.json",
-                                                                                           linter_file=True)
-                if not part_build_log_combined:
-                    GlobalSettings.logger.debug(f"Lint_log.json not found yet for {s3_results_key}, wait and retry")
-                    time.sleep(2)
-                    part_build_log_combined = ClientLinterCallback.merge_build_status_for_file(part_build_log,
-                                                                                               s3_results_key,
-                                                                                               "lint_log.json",
-                                                                                               linter_file=True)
-
-                if part_build_log_combined:
-                    build_log = ClientLinterCallback.merge_results_logs(build_log, part_build_log_combined,
-                                                                        linter_file=False)
-                    ClientLinterCallback.upload_logs(s3_results_key, part_build_log_combined, output_dir)
-                    return build_log
-                else:
-                    GlobalSettings.logger.debug(f"Lint_log.json not found for {s3_results_key}")
-            else:
-                GlobalSettings.logger.debug(f"convert_log.json not found for {s3_results_key}")
-
-            return None
-
-        else:
-            build_log = ClientLinterCallback.merge_results_logs(build_log, part_build_log, linter_file=False)
-            return build_log
+    #     # Flag this part as done
+    #     ClientLinterCallback.upload_build_log(build_log, 'merged.json', output_dir, s3_results_key)
+    #     # Update build_log to start deploy of this part
+    #     ClientLinterCallback.upload_build_log(build_log, 'build_log.json', output_dir, s3_results_key, cache_time=600)
+    #     # GlobalSettings.logger.info("Deployment on AWS should automatically begin now_")
+    #     return
 
 
-    @staticmethod
-    def is_convert_finished(s3_results_key):
-        key = f'{s3_results_key}/finished'
-        try:
-            convert_finished = GlobalSettings.cdn_s3_handler().key_exists(key)
-        except Exception:
-            convert_finished = False
-        return convert_finished
+    # @staticmethod
+    # def merge_build_status_for_part(build_log, s3_results_key, output_dir):
+    #     """
+    #     merges convert and linter status for this part of conversion into build_log.  Returns None if part not finished.
+    #     :param output_dir:
+    #     :param build_log:
+    #     :param s3_results_key:
+    #     :return:
+    #     """
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.merge_build_status_for_part({build_log}, {s3_results_key}, {output_dir})…")
+
+    #     part_build_log = ClientLinterCallback.get_results(s3_results_key, "merged.json")  # see if already merged
+    #     if not part_build_log:
+    #         convert_finished = ClientLinterCallback.is_convert_finished(s3_results_key)
+    #         if not convert_finished:
+    #             GlobalSettings.logger.debug(f"Convert not yet finished for {s3_results_key}")
+    #             return None
+
+    #         part_build_log = ClientLinterCallback.get_results(s3_results_key, "convert_log.json")
+    #         if part_build_log:
+    #             part_build_log_combined = ClientLinterCallback.merge_build_status_for_file(part_build_log,
+    #                                                                                        s3_results_key,
+    #                                                                                        "lint_log.json",
+    #                                                                                        linter_file=True)
+    #             if not part_build_log_combined:
+    #                 GlobalSettings.logger.debug(f"Lint_log.json not found yet for {s3_results_key}, wait and retry")
+    #                 time.sleep(2)
+    #                 part_build_log_combined = ClientLinterCallback.merge_build_status_for_file(part_build_log,
+    #                                                                                            s3_results_key,
+    #                                                                                            "lint_log.json",
+    #                                                                                            linter_file=True)
+
+    #             if part_build_log_combined:
+    #                 build_log = ClientLinterCallback.merge_results_logs(build_log, part_build_log_combined,
+    #                                                                     linter_file=False)
+    #                 ClientLinterCallback.upload_logs(s3_results_key, part_build_log_combined, output_dir)
+    #                 return build_log
+    #             else:
+    #                 GlobalSettings.logger.debug(f"Lint_log.json not found for {s3_results_key}")
+    #         else:
+    #             GlobalSettings.logger.debug(f"convert_log.json not found for {s3_results_key}")
+
+    #         return None
+
+    #     else:
+    #         build_log = ClientLinterCallback.merge_results_logs(build_log, part_build_log, linter_file=False)
+    #         return build_log
 
 
-    @staticmethod
-    def get_results(s3_results_key, file_name):
-        key = f'{s3_results_key}/{file_name}'
-        file_results = GlobalSettings.cdn_s3_handler().get_json(key)
-        return file_results
+    # @staticmethod
+    # def is_convert_finished(s3_results_key):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.is_convert_finished({s3_results_key})…")
+    #     key = f'{s3_results_key}/finished'
+    #     try:
+    #         convert_finished = GlobalSettings.cdn_s3_handler().key_exists(key)
+    #     except Exception:
+    #         convert_finished = False
+    #     return convert_finished
 
 
-    @staticmethod
-    def merge_build_status_for_file(build_log, s3_results_key, file_name, linter_file=False):
-        key = f'{s3_results_key}/{file_name}'
-        file_results = GlobalSettings.cdn_s3_handler().get_json(key)
-        if file_results:
-            build_log = ClientLinterCallback.merge_results_logs(build_log, file_results, linter_file)
-            return build_log
-        return None
+    # @staticmethod
+    # def get_results(s3_results_key, file_name):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.get_results({s3_results_key}, {file_name})…")
+    #     key = f'{s3_results_key}/{file_name}'
+    #     file_results = GlobalSettings.cdn_s3_handler().get_json(key)
+    #     return file_results
 
-    @staticmethod
-    def merge_results_logs(build_log, file_results, linter_file):
-        if not build_log:
-            return file_results
-        if file_results:
-            ClientLinterCallback.merge_lists(build_log, file_results, 'log')
-            ClientLinterCallback.merge_lists(build_log, file_results, 'warnings')
-            ClientLinterCallback.merge_lists(build_log, file_results, 'errors')
-            if not linter_file and ('success' in file_results) and (file_results['success'] is False):
-                build_log['success'] = file_results['success']
-        return build_log
 
-    @staticmethod
-    def merge_lists(build_log, file_results, key):
-        if key in file_results:
-            value = file_results[key]
-            if value:
-                if (key in build_log) and (build_log[key]):
-                    build_log[key] += value
-                else:
-                    build_log[key] = value
+    # @staticmethod
+    # def merge_build_status_for_file(build_log, s3_results_key, file_name, linter_file=False):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.merge_build_status_for_file({build_log}, {s3_results_key}, {file_name}, {linter_file})…")
+    #     key = f'{s3_results_key}/{file_name}'
+    #     file_results = GlobalSettings.cdn_s3_handler().get_json(key)
+    #     if file_results:
+    #         build_log = ClientLinterCallback.merge_results_logs(build_log, file_results, linter_file)
+    #         return build_log
+    #     return None
 
-    @staticmethod
-    def update_project_file(build_log, output_dir):
-        commit_id = build_log['commit_id']
-        user_name = build_log['repo_owner']
-        repo_name = build_log['repo_name']
-        project_json_key = f'u/{user_name}/{repo_name}/project.json'
-        project_json = GlobalSettings.cdn_s3_handler().get_json(project_json_key)
-        project_json['user'] = user_name
-        project_json['repo'] = repo_name
-        project_json['repo_url'] = f'https://{GlobalSettings.gogs_url}/{user_name}/{repo_name}'
-        commit = {
-            'id': commit_id,
-            'created_at': build_log['created_at'],
-            'status': build_log['status'],
-            'success': build_log['success'],
-            'started_at': None,
-            'ended_at': None
-        }
-        if 'started_at' in build_log:
-            commit['started_at'] = build_log['started_at']
-        if 'ended_at' in build_log:
-            commit['ended_at'] = build_log['ended_at']
-        if 'commits' not in project_json:
-            project_json['commits'] = []
-        commits = []
-        for c in project_json['commits']:
-            if c['id'] != commit_id:
-                commits.append(c)
-        commits.append(commit)
-        project_json['commits'] = commits
-        project_file = os.path.join(output_dir, 'project.json')
-        write_file(project_file, project_json)
-        GlobalSettings.cdn_s3_handler().upload_file(project_file, project_json_key, cache_time=0)
-        return project_json
+
+    # @staticmethod
+    # def merge_results_logs(build_log, file_results, linter_file):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.merge_results_logs({build_log}, {file_results}, {linter_file})…")
+    #     if not build_log:
+    #         return file_results
+    #     if file_results:
+    #         ClientLinterCallback.merge_dicts(build_log, file_results, 'log')
+    #         ClientLinterCallback.merge_dicts(build_log, file_results, 'warnings')
+    #         ClientLinterCallback.merge_dicts(build_log, file_results, 'errors')
+    #         if not linter_file and ('success' in file_results) and (file_results['success'] is False):
+    #             build_log['success'] = file_results['success']
+    #     return build_log
+
+
+    # @staticmethod
+    # def merge_dicts(build_log, file_results, key):
+    #     """
+    #     Used for merging log dicts from various sub-processes.
+
+    #     build_log is a dict
+    #     """
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.merge_dicts({build_log}, {file_results}, {key})…")
+    #     if key in file_results:
+    #         value = file_results[key]
+    #         if value:
+    #             if (key in build_log) and (build_log[key]):
+    #                 build_log[key] += value
+    #             else:
+    #                 build_log[key] = value
+    # # end of merge_dicts function
+
+
+    # @staticmethod
+    # def update_project_file(build_log, output_dir):
+    #     GlobalSettings.logger.debug(f"ClientLinterCallback.update_project_file({build_log}, {output_dir})…")
+    #     commit_id = build_log['commit_id']
+    #     user_name = build_log['repo_owner']
+    #     repo_name = build_log['repo_name']
+    #     project_json_key = f'u/{user_name}/{repo_name}/project.json'
+    #     project_json = GlobalSettings.cdn_s3_handler().get_json(project_json_key)
+    #     project_json['user'] = user_name
+    #     project_json['repo'] = repo_name
+    #     project_json['repo_url'] = f'https://{GlobalSettings.gogs_url}/{user_name}/{repo_name}'
+    #     commit = {
+    #         'id': commit_id,
+    #         'created_at': build_log['created_at'],
+    #         'status': build_log['status'],
+    #         'success': build_log['success'],
+    #         'started_at': None,
+    #         'ended_at': None
+    #     }
+    #     if 'started_at' in build_log:
+    #         commit['started_at'] = build_log['started_at']
+    #     if 'ended_at' in build_log:
+    #         commit['ended_at'] = build_log['ended_at']
+    #     if 'commits' not in project_json:
+    #         project_json['commits'] = []
+    #     commits = []
+    #     for c in project_json['commits']:
+    #         if c['id'] != commit_id:
+    #             commits.append(c)
+    #     commits.append(commit)
+    #     project_json['commits'] = commits
+    #     project_file = os.path.join(output_dir, 'project.json')
+    #     write_file(project_file, project_json)
+    #     GlobalSettings.cdn_s3_handler().upload_file(project_file, project_json_key, cache_time=0)
+    #     return project_json
+    # # end of update_project_file function

--- a/door43_tools/project_deployer.py
+++ b/door43_tools/project_deployer.py
@@ -23,8 +23,8 @@ class ProjectDeployer:
     by applying the door43.org template to the raw html files
     """
 
-    def __init__(self, temp_dir, unzip_dir):
-        # GlobalSettings.logger.debug(f"ProjectDeployer.__init__({unzip_dir})…")
+    def __init__(self, unzip_dir, temp_dir):
+        GlobalSettings.logger.debug(f"ProjectDeployer.__init__({unzip_dir}, {temp_dir})…")
         self.unzip_dir = unzip_dir
         self.temp_dir = tempfile.mkdtemp(prefix='deployer_', dir=temp_dir)
 

--- a/door43_tools/project_deployer.py
+++ b/door43_tools/project_deployer.py
@@ -23,7 +23,9 @@ class ProjectDeployer:
     by applying the door43.org template to the raw html files
     """
 
-    def __init__(self):
+    def __init__(self, unzip_dir):
+        # GlobalSettings.logger.debug(f"ProjectDeployer.__init__({unzip_dir})…")
+        self.unzip_dir = unzip_dir
         self.temp_dir = tempfile.mkdtemp(suffix='',
                             prefix='Door43_deployer_' + datetime.utcnow().strftime('%Y-%m-%d_%H:%M:%S_'))
 
@@ -42,28 +44,28 @@ class ProjectDeployer:
     #     self.close()
 
 
-    def download_buildlog_and_deploy_revision_to_door43(self, build_log_key):
-        """
-        Deploys a single revision of a project to door43.org
-        :param string build_log_key:
-        :return bool:
+    # def download_buildlog_and_deploy_revision_to_door43(self, build_log_key):
+    #     """
+    #     Deploys a single revision of a project to door43.org
+    #     :param string build_log_key:
+    #     :return bool:
 
-        Was used by Lambda function
-            but now only called by test routines.
-        """
-        build_log = None
-        try:
-            build_log = GlobalSettings.cdn_s3_handler().get_json(build_log_key, catch_exception=False)
-        except Exception as e:
-            GlobalSettings.logger.debug(f"Deploying error could not access {build_log_key}: {e}")
-            pass
+    #     Was used by Lambda function
+    #         but now only called by test routines.
+    #     """
+    #     build_log = None
+    #     try:
+    #         build_log = GlobalSettings.cdn_s3_handler().get_json(build_log_key, catch_exception=False)
+    #     except Exception as e:
+    #         GlobalSettings.logger.debug(f"Deploying error could not access {build_log_key}: {e}")
+    #         pass
 
-        if not build_log or 'commit_id' not in build_log or 'repo_owner' not in build_log \
-                or 'repo_name' not in build_log:
-            GlobalSettings.logger.debug(f"Exiting, Invalid build log at {build_log_key}: {build_log}")
-            return False
+    #     if not build_log or 'commit_id' not in build_log or 'repo_owner' not in build_log \
+    #             or 'repo_name' not in build_log:
+    #         GlobalSettings.logger.debug(f"Exiting, Invalid build log at {build_log_key}: {build_log}")
+    #         return False
 
-        return self.deploy_revision_to_door43(build_log)
+    #     return self.deploy_revision_to_door43(build_log)
 
 
     def deploy_revision_to_door43(self, build_log):
@@ -81,36 +83,38 @@ class ProjectDeployer:
 
         s3_commit_key = f'u/{user}/{repo_name}/{commit_id}'
         s3_repo_key = f'u/{user}/{repo_name}'
-        download_key = s3_commit_key
+        # download_key = s3_commit_key
 
         do_part_template_only = False
         do_multipart_merge = False
-        if 'multiple' in build_log:
-            do_multipart_merge = build_log['multiple']
-            GlobalSettings.logger.debug(f"Found multi-part merge: {download_key}")
+        assert 'multiple' not in build_log
+        assert 'part' not in build_log
+        # if 'multiple' in build_log:
+        #     do_multipart_merge = build_log['multiple']
+        #     GlobalSettings.logger.debug(f"Found multi-part merge: {download_key}")
 
-            prefix = download_key + '/'
-            undeployed = self.get_undeployed_parts(prefix)
-            if len(undeployed) > 0:
-                GlobalSettings.logger.debug(f"Exiting, Parts not yet deployed: {undeployed}")
-                return False
+        #     prefix = download_key + '/'
+        #     undeployed = self.get_undeployed_parts(prefix)
+        #     if len(undeployed) > 0:
+        #         GlobalSettings.logger.debug(f"Exiting, Parts not yet deployed: {undeployed}")
+        #         return False
 
-            key_deployed_ = download_key + '/final_deployed'
-            if GlobalSettings.cdn_s3_handler().key_exists(key_deployed_):
-                GlobalSettings.logger.debug(f"Exiting, Already merged parts: {download_key}")
-                return False
-            self.write_data_to_file(self.temp_dir, key_deployed_, 'final_deployed', ' ')  # flag that deploy has begun
-            GlobalSettings.logger.debug(f"Continuing with merge: {download_key}")
+        #     key_deployed_ = download_key + '/final_deployed'
+        #     if GlobalSettings.cdn_s3_handler().key_exists(key_deployed_):
+        #         GlobalSettings.logger.debug(f"Exiting, Already merged parts: {download_key}")
+        #         return False
+        #     self.write_data_to_file(self.temp_dir, key_deployed_, 'final_deployed', ' ')  # flag that deploy has begun
+        #     GlobalSettings.logger.debug(f"Continuing with merge: {download_key}")
 
-        elif 'part' in build_log:
-            part = build_log['part']
-            download_key += '/' + part
-            do_part_template_only = True
-            GlobalSettings.logger.debug(f"Found partial: {download_key}")
+        # elif 'part' in build_log:
+        #     part = build_log['part']
+        #     download_key += '/' + part
+        #     do_part_template_only = True
+        #     GlobalSettings.logger.debug(f"Found partial: {download_key}")
 
-            if not GlobalSettings.cdn_s3_handler().key_exists(download_key + '/finished'):
-                GlobalSettings.logger.debug("Exiting, Not ready to process partial")
-                return False
+        #     if not GlobalSettings.cdn_s3_handler().key_exists(download_key + '/finished'):
+        #         GlobalSettings.logger.debug("Exiting, Not ready to process partial")
+        #         return False
 
         source_dir = tempfile.mkdtemp(prefix='source_', dir=self.temp_dir)
         output_dir = tempfile.mkdtemp(prefix='output_', dir=self.temp_dir)
@@ -123,16 +127,16 @@ class ProjectDeployer:
         GlobalSettings.door43_s3_handler().download_file(template_key, template_file)
 
         if not do_multipart_merge:
-            source_dir, success = self.template_converted_files(build_log, download_key, output_dir, repo_name,
+            source_dir, success = self.template_converted_files(build_log, output_dir, repo_name,
                                                                 resource_type, s3_commit_key, source_dir, start,
                                                                 template_file)
             if not success:
                 return False
-        else:
-            source_dir, success = self.multipart_master_merge(s3_commit_key, resource_type, download_key, output_dir,
-                                                              source_dir, start, template_file)
-            if not success:
-                return False
+        # else:
+        #     source_dir, success = self.multipart_master_merge(s3_commit_key, resource_type, download_key, output_dir,
+        #                                                       source_dir, start, template_file)
+        #     if not success:
+        #         return False
 
         #######################
         #
@@ -153,109 +157,111 @@ class ProjectDeployer:
             if not os.path.exists(output_file) and not os.path.isdir(filename):
                 copyfile(filename, output_file)
 
-            if do_part_template_only:  # move files to common area
-                basename = os.path.basename(filename)
-                if basename not in ['finished', 'build_log.json', 'index.html', 'merged.json', 'lint_log.json']:
-                    GlobalSettings.logger.debug(f"Moving {basename} to common area…")
-                    GlobalSettings.cdn_s3_handler().upload_file(filename, s3_commit_key + '/' + basename, cache_time=0)
-                    GlobalSettings.cdn_s3_handler().delete_file(download_key + '/' + basename)
+            # if do_part_template_only:  # move files to common area
+            #     basename = os.path.basename(filename)
+            #     if basename not in ['finished', 'build_log.json', 'index.html', 'merged.json', 'lint_log.json']:
+            #         GlobalSettings.logger.debug(f"Moving {basename} to common area…")
+            #         GlobalSettings.cdn_s3_handler().upload_file(filename, s3_commit_key + '/' + basename, cache_time=0)
+            #         GlobalSettings.cdn_s3_handler().delete_file(download_key + '/' + basename)
 
         # Save master build_log.json
+        build_log['ended_at'] = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
         file_utils.write_file(os.path.join(output_dir, 'build_log.json'), build_log)
         GlobalSettings.logger.debug(f"Final build_log.json: {json.dumps(build_log)[:256]} …")
 
         # Upload all files to the door43.org bucket
         GlobalSettings.logger.info(f"Uploading all files to the website bucket: {GlobalSettings.door43_bucket_name} …")
         for root, dirs, files in os.walk(output_dir):
-            for f in sorted(files):
-                path = os.path.join(root, f)
-                if os.path.isdir(path):
+            for filename in sorted(files):
+                filepath = os.path.join(root, filename)
+                if os.path.isdir(filepath):
                     continue
-                key = s3_commit_key + path.replace(output_dir, '').replace(os.path.sep, '/')
-                GlobalSettings.logger.debug(f"Uploading {path} to {key} …")
-                GlobalSettings.door43_s3_handler().upload_file(path, key, cache_time=0)
+                key = s3_commit_key + filepath.replace(output_dir, '').replace(os.path.sep, '/')
+                GlobalSettings.logger.debug(f"Uploading {filename} to {key} …")
+                GlobalSettings.door43_s3_handler().upload_file(filepath, key, cache_time=0)
 
-        if not do_part_template_only:
-            # Now we place json files and redirect index.html for the whole repo to this index.html file
-            try:
-                GlobalSettings.door43_s3_handler().copy(from_key=f'{s3_repo_key}/project.json', from_bucket=GlobalSettings.cdn_bucket_name)
-                GlobalSettings.door43_s3_handler().copy(from_key=f'{s3_commit_key}/manifest.json',
-                                             to_key=f'{s3_repo_key}/manifest.json')
-                GlobalSettings.door43_s3_handler().redirect(s3_repo_key, '/' + s3_commit_key)
-                GlobalSettings.door43_s3_handler().redirect(s3_repo_key + '/index.html', '/' + s3_commit_key)
-                self.write_data_to_file(output_dir, s3_commit_key, 'deployed', ' ')  # flag that deploy has finished
-            except:
-                pass
+        # if not do_part_template_only:
+        # Now we place json files and redirect index.html for the whole repo to this index.html file
+        try:
+            GlobalSettings.door43_s3_handler().copy(from_key=f'{s3_repo_key}/project.json', from_bucket=GlobalSettings.cdn_bucket_name)
+            GlobalSettings.door43_s3_handler().copy(from_key=f'{s3_commit_key}/manifest.json',
+                                            to_key=f'{s3_repo_key}/manifest.json')
+            GlobalSettings.door43_s3_handler().redirect(s3_repo_key, '/' + s3_commit_key)
+            GlobalSettings.door43_s3_handler().redirect(s3_repo_key + '/index.html', '/' + s3_commit_key)
+            self.write_data_to_file(output_dir, s3_commit_key, 'deployed', ' ')  # flag that deploy has finished
+        except:
+            pass
 
-        else:  # if processing part of multi-part merge
-            self.write_data_to_file(output_dir, download_key, 'deployed', ' ')  # flag that deploy has finished
-            if GlobalSettings.cdn_s3_handler().key_exists(s3_commit_key + '/final_build_log.json'):
-                GlobalSettings.logger.debug("final build detected")
-                GlobalSettings.logger.debug("conversions all finished, trigger final merge")
-                GlobalSettings.cdn_s3_handler().copy(from_key=s3_commit_key + '/final_build_log.json',
-                                          to_key=s3_commit_key + '/build_log.json')
+        # else:  # if processing part of multi-part merge
+        #     self.write_data_to_file(output_dir, download_key, 'deployed', ' ')  # flag that deploy has finished
+        #     if GlobalSettings.cdn_s3_handler().key_exists(s3_commit_key + '/final_build_log.json'):
+        #         GlobalSettings.logger.debug("final build detected")
+        #         GlobalSettings.logger.debug("conversions all finished, trigger final merge")
+        #         GlobalSettings.cdn_s3_handler().copy(from_key=s3_commit_key + '/final_build_log.json',
+        #                                   to_key=s3_commit_key + '/build_log.json')
 
         elapsed_seconds = int(time.time() - start)
-        GlobalSettings.logger.debug(f"deploy type partial={do_part_template_only}, multi_merge={do_multipart_merge}")
-        GlobalSettings.logger.debug(f"deploy completed in {elapsed_seconds} seconds")
+        GlobalSettings.logger.debug(f"Deploy type partial={do_part_template_only}, multi_merge={do_multipart_merge}")
+        GlobalSettings.logger.debug(f"Deploy completed in {elapsed_seconds} seconds.")
         self.close()
         return True
 
 
-    def multipart_master_merge(self, s3_commit_key, resource_type, download_key, output_dir, source_dir, start,
-                               template_file):
-        prefix = download_key + '/'
-        GlobalSettings.door43_s3_handler().download_dir(prefix, source_dir)  # get previous templated files
-        source_dir = os.path.join(source_dir, download_key)
-        files = sorted(glob(os.path.join(source_dir, '*.*')))
-        for f in files:
-            GlobalSettings.logger.debug("Downloaded: " + f)
-        fname = os.path.join(source_dir, 'index.html')
-        if os.path.isfile(fname):
-            os.remove(fname)  # remove index if already exists
-        elapsed_seconds = int(time.time() - start)
-        GlobalSettings.logger.debug("deploy download completed in " + str(elapsed_seconds) + " seconds")
-        templater = init_template(resource_type, source_dir, output_dir, template_file)
-        # restore index from previous passes
-        index_json = self.get_templater_index(s3_commit_key, 'index.json')
-        templater.titles = index_json['titles']
-        templater.chapters = index_json['chapters']
-        templater.book_codes = index_json['book_codes']
-        templater.already_converted = templater.files  # do not reconvert files
-        # merge the source files with the template
-        try:
-            self.run_templater(templater)
-            success = True
-        # except Exception as e:
-        except:
-            GlobalSettings.logger.error(f"Error multi-part applying template {template_file} to resource type {resource_type}")
-            self.close()
-            success = False
-        return source_dir, success
+    # def multipart_master_merge(self, s3_commit_key, resource_type, download_key, output_dir, source_dir, start,
+    #                            template_file):
+    #     prefix = download_key + '/'
+    #     GlobalSettings.door43_s3_handler().download_dir(prefix, source_dir)  # get previous templated files
+    #     source_dir = os.path.join(source_dir, download_key)
+    #     files = sorted(glob(os.path.join(source_dir, '*.*')))
+    #     for f in files:
+    #         GlobalSettings.logger.debug("Downloaded: " + f)
+    #     fname = os.path.join(source_dir, 'index.html')
+    #     if os.path.isfile(fname):
+    #         os.remove(fname)  # remove index if already exists
+    #     elapsed_seconds = int(time.time() - start)
+    #     GlobalSettings.logger.debug("deploy download completed in " + str(elapsed_seconds) + " seconds")
+    #     templater = init_template(resource_type, source_dir, output_dir, template_file)
+    #     # restore index from previous passes
+    #     index_json = self.get_templater_index(s3_commit_key, 'index.json')
+    #     templater.titles = index_json['titles']
+    #     templater.chapters = index_json['chapters']
+    #     templater.book_codes = index_json['book_codes']
+    #     templater.already_converted = templater.files  # do not reconvert files
+    #     # merge the source files with the template
+    #     try:
+    #         self.run_templater(templater)
+    #         success = True
+    #     # except Exception as e:
+    #     except:
+    #         GlobalSettings.logger.error(f"Error multi-part applying template {template_file} to resource type {resource_type}")
+    #         self.close()
+    #         success = False
+    #     return source_dir, success
 
 
-    def get_undeployed_parts(self, prefix):
-        unfinished = []
-        for o in GlobalSettings.cdn_s3_handler().get_objects(prefix=prefix, suffix='/build_log.json'):
-            parts = o.key.split(prefix)
-            if len(parts) == 2:
-                parts = parts[1].split('/')
-                if len(parts) > 1:
-                    part_num = parts[0]
-                    deployed_key = prefix + part_num + '/deployed'
-                    if not GlobalSettings.cdn_s3_handler().key_exists(deployed_key):
-                        GlobalSettings.logger.debug(f"Part {part_num} unfinished")
-                        unfinished.append(part_num)
-        return unfinished
+    # def get_undeployed_parts(self, prefix):
+    #     unfinished = []
+    #     for o in GlobalSettings.cdn_s3_handler().get_objects(prefix=prefix, suffix='/build_log.json'):
+    #         parts = o.key.split(prefix)
+    #         if len(parts) == 2:
+    #             parts = parts[1].split('/')
+    #             if len(parts) > 1:
+    #                 part_num = parts[0]
+    #                 deployed_key = prefix + part_num + '/deployed'
+    #                 if not GlobalSettings.cdn_s3_handler().key_exists(deployed_key):
+    #                     GlobalSettings.logger.debug(f"Part {part_num} unfinished")
+    #                     unfinished.append(part_num)
+    #     return unfinished
 
 
-    def template_converted_files(self, build_log, download_key, output_dir, repo_name, resource_type, s3_commit_key,
-                                 source_dir, start, template_file):
-        # GlobalSettings.logger.debug("template_converted_files()")
-        GlobalSettings.cdn_s3_handler().download_dir(download_key + '/', source_dir)
-        source_dir = os.path.join(source_dir, download_key.replace('/', os.path.sep))
-        elapsed_seconds = int(time.time() - start)
-        GlobalSettings.logger.debug(f"Deploy download completed in {elapsed_seconds} seconds")
+    def template_converted_files(self, build_log, output_dir, repo_name, resource_type, s3_commit_key,
+                                 source_dir, start_time, template_file):
+        GlobalSettings.logger.debug("template_converted_files()…")
+        # GlobalSettings.cdn_s3_handler().download_dir(download_key + '/', source_dir)
+        # source_dir = os.path.join(source_dir, download_key.replace('/', os.path.sep))
+        # elapsed_seconds = int(time.time() - start_time)
+        # GlobalSettings.logger.debug(f"Deploy download completed in {elapsed_seconds} seconds")
+        source_dir = self.unzip_dir
         html_files = sorted(glob(os.path.join(source_dir, '*.html')))
         if len(html_files) < 1:
             content = ''

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,11 +13,11 @@ pyyaml==3.13
 py-dateutil==2.2.0
 
 # sqlalchemy is used by manifest
-sqlalchemy==1.2.17
+sqlalchemy==1.2.18
 pymysql==0.9.3
 
 # boto3 is used by aws_tools
-boto3==1.9.88
+boto3==1.9.106
 
 #gogs_client is used by gogs_tools
 gogs_client==1.0.6

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,11 +13,11 @@ pyyaml==3.13
 py-dateutil==2.2.0
 
 # sqlalchemy is used by manifest
-sqlalchemy==1.2.17
+sqlalchemy==1.2.18
 pymysql==0.9.3
 
 # boto3 is used by aws_tools
-boto3==1.9.88
+boto3==1.9.106
 
 #gogs_client is used by gogs_tools
 gogs_client==1.0.6


### PR DESCRIPTION
This was quite a major change to the callback function which had previously cobbled together various modular components from tX-manager. Now it's adjusted to use local files rather than relying on AWS uploads and downloads between each component. There is some risk that this optimisation might have changed some behaviour that external components rely on, e.g., if a specific file in the cdn is checked for but no longer uploaded, but hopefully it's ok.